### PR TITLE
fix: When choosing strategy, check if the grouped solution has any split

### DIFF
--- a/src/encoding/evm/strategy_encoder/strategy_encoders.rs
+++ b/src/encoding/evm/strategy_encoder/strategy_encoders.rs
@@ -76,7 +76,7 @@ impl StrategyEncoder for SingleSwapStrategyEncoder {
         let number_of_groups = grouped_swaps.len();
         if number_of_groups != 1 {
             return Err(EncodingError::InvalidInput(format!(
-                "Executor strategy only supports exactly one swap for non-groupable protocols. Found {number_of_groups}",
+                "Single strategy only supports exactly one swap for non-groupable protocols. Found {number_of_groups}",
             )))
         }
 


### PR DESCRIPTION
This came from a reported bug where the single strategy was being chosen for a solution on a groupable protocol (univ4) but the solution was composed of 2 splits only. Like a trade from WETH to USDC through two different univ4 pools