### PR TITLE
fix: revert wrong 0.45.0 release, will trigger 0.166.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,3 @@
-## [0.45.0](https://github.com/propeller-heads/tycho-execution/compare/0.44.0...0.45.0) (2026-03-23)
-
-
-### Features
-
-* Add release and notify workflows ([560c868](https://github.com/propeller-heads/tycho-execution/commit/560c868a3de31fdbf57be57f46a12d3481ecc8f2))
-* Rename tycho-contracts -> tycho-execution ([ca197f1](https://github.com/propeller-heads/tycho-execution/commit/ca197f190c6f2f03d1e24aa66b0615e56dbe24c1))
-
-
-### Bug Fixes
-
-* Fix cargo audit ([bf953d0](https://github.com/propeller-heads/tycho-execution/commit/bf953d02ea92c3d9e35c256ab0db7ec5bd8b6e6c))
-
 ## [0.44.0](https://github.com/propeller-heads/tycho-execution/compare/0.43.0...0.44.0) (2026-03-20)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.45.0"
+version = "0.166.0"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tycho-execution"
-version = "0.45.0"
+version = "0.166.0"
 edition = "2021"
 description = "Provides tools for encoding and executing swaps against Tycho router and protocol executors."
 repository = "https://github.com/propeller-heads/tycho-execution"


### PR DESCRIPTION
Semantic-release created 0.45.0 (based on last tag 0.44.0) instead of 0.166.0.

This revert undoes the wrong release commit. A `0.165.1` tag has been planted on the pre-PR commit so that when this merges, semantic-release sees the feat: commits from the ENG-5536 PR and produces 0.166.0.