### PR TITLE
fix: Revoke unconsumed approvals

### DIFF
--- a/foundry/src/Dispatcher.sol
+++ b/foundry/src/Dispatcher.sol
@@ -85,7 +85,7 @@ contract Dispatcher is TransferManager {
      * @dev Calls an executor, assumes swap.protocolData contains
      *  protocol-specific data required by the executor.
      */
-    // slither-disable-next-line delegatecall-loop,assembly,controlled-delegatecall
+    // slither-disable-next-line delegatecall-loop,assembly,controlled-delegatecall,cyclomatic-complexity
     function _callSwapOnExecutor(
         address executor,
         uint256 amount,
@@ -160,6 +160,11 @@ contract Dispatcher is TransferManager {
             tstore(_CURRENTLY_SWAPPING_EXECUTOR_SLOT, 0)
             tstore(_IS_FIRST_SWAP_SLOT, 0)
             tstore(_IS_SPLIT_SWAP_SLOT, 0)
+        }
+
+        // Revoke any lingering allowance the protocol didn't consume.
+        if (transferType == TransferType.ProtocolWillDebit) {
+            _revokeUnconsumedApproval(tokenIn, transferReceiver);
         }
 
         if (!success) {
@@ -267,6 +272,11 @@ contract Dispatcher is TransferManager {
                         : abi.encodePacked("Callback failed")
                 )
             );
+        }
+
+        // Revoke any lingering allowance the protocol didn't consume.
+        if (transferType == TransferType.ProtocolWillDebit) {
+            _revokeUnconsumedApproval(tokenIn, receiver);
         }
 
         // to prevent multiple callbacks

--- a/foundry/src/TransferManager.sol
+++ b/foundry/src/TransferManager.sol
@@ -250,6 +250,20 @@ contract TransferManager is Vault {
     }
 
     /**
+     * @dev Revokes a token approval if the spender didn't fully consume it.
+     * In the normal case the protocol consumed the approval, so we skip the expensive
+     * forceApprove.
+     */
+    // slither-disable-next-line calls-loop
+    function _revokeUnconsumedApproval(address token, address spender)
+        internal
+    {
+        if (IERC20(token).allowance(address(this), spender) > 0) {
+            IERC20(token).forceApprove(spender, 0);
+        }
+    }
+
+    /**
      * @dev Transfers tokens from user wallet using either Permit2 or regular transferFrom.
      * Validates the transfer doesn't exceed allowed amount and updates allowance tracking.
      * @return The actual amount received by the receiver, measured as the balance

--- a/foundry/test/TychoRouterSequentialSwap.t.sol
+++ b/foundry/test/TychoRouterSequentialSwap.t.sol
@@ -661,6 +661,8 @@ contract TychoRouterSequentialSwapTest is TychoRouterTestSetup {
         assertEq(IERC20(USDC_ADDR).balanceOf(tychoRouterAddr), vaultUsdc);
         // No leftover WETH in router
         assertEq(IERC20(WETH_ADDR).balanceOf(tychoRouterAddr), 0);
+        // No lingering WETH allowance to the fake pool
+        assertEq(IERC20(WETH_ADDR).allowance(tychoRouterAddr, fakePool), 0);
 
         vm.stopPrank();
     }
@@ -733,6 +735,8 @@ contract TychoRouterSequentialSwapTest is TychoRouterTestSetup {
         assertEq(IERC20(WETH_ADDR).balanceOf(tychoRouterAddr), vaultWeth);
         // No leftover USDC in router
         assertEq(IERC20(USDC_ADDR).balanceOf(tychoRouterAddr), 0);
+        // No lingering WETH allowance to the fake pool
+        assertEq(IERC20(WETH_ADDR).allowance(tychoRouterAddr, fakePool), 0);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
- Avoids exploits where an approval could be used by a malicious target at a later time.
- Added slither ignore cyclomatic-complexity: The dispatcher is a central point so the 12 possible paths in this function are necessary for full functionality
- Gas is good:

```
  ┌───────────────────────────────────────────────────┬───────────────────┐                                                                                                                                        
  │                   Protocol type                   │ Per-swap overhead │              
  ├───────────────────────────────────────────────────┼───────────────────┤                                                                                                                                        
  │ Non-ProtocolWillDebit (UniswapV2, V3, V4, etc.)   │               +58 │              
  ├───────────────────────────────────────────────────┼───────────────────┤
  │ Curve (ProtocolWillDebit, approval consumed)      │            +1,035 │                                                                                                                                        
  ├───────────────────────────────────────────────────┼───────────────────┤                                                                                                                                        
  │ BalancerV2 (ProtocolWillDebit, approval consumed) │            +1,088 │                                                                                                                                        
  └───────────────────────────────────────────────────┴───────────────────┘  

  ┌──────────────────────────┬───────┬───────────────┬─────────────────┬─────────┐                                                                                                                                 
  │         Function         │ Tests │ Main (median) │ Branch (median) │  Diff   │        
  ├──────────────────────────┼───────┼───────────────┼─────────────────┼─────────┤                                                                                                                                 
  │ singleSwap               │    12 │       203,743 │         203,802 │     +59 │                                                                                                                                 
  ├──────────────────────────┼───────┼───────────────┼─────────────────┼─────────┤                                                                                                                                 
  │ singleSwapPermit2        │     2 │       179,745 │         179,803 │     +58 │     
  ├──────────────────────────┼───────┼───────────────┼─────────────────┼─────────┤
  │ exposedSequentialSwap    │     1 │       121,293 │         121,385 │     +92 │
  ├──────────────────────────┼───────┼───────────────┼─────────────────┼─────────┤                                                                                                                                 
  │ sequentialSwap           │    11 │       251,838 │         252,083 │    +245 │
  ├──────────────────────────┼───────┼───────────────┼─────────────────┼─────────┤                                                                                                                                 
  │ sequentialSwapPermit2    │     4 │       265,135 │         265,381 │    +246 │     
  ├──────────────────────────┼───────┼───────────────┼─────────────────┼─────────┤                                                                                                                                 
  │ exposedSplitSwap         │     2 │        83,867 │          83,913 │     +46 │       
  ├──────────────────────────┼───────┼───────────────┼─────────────────┼─────────┤                                                                                                                                 
  │ splitSwap                │     5 │       375,639 │         375,970 │    +331 │
  ├──────────────────────────┼───────┼───────────────┼─────────────────┼─────────┤                                                                                                                                 
  │ splitSwapPermit2         │     4 │       384,661 │         385,045 │    +384 │       
  ├──────────────────────────┼───────┼───────────────┼─────────────────┼─────────┤                                                                                                                                 
  │ splitSwapUsingVault      │     1 │       205,068 │         205,235 │    +167 │
  └──────────────────────────┴───────┴───────────────┴─────────────────┴─────────┘
```