### PR TITLE
feat: Change Swap token_in/token_out from Token to Bytes

### DIFF
--- a/examples/encoding-example/main.rs
+++ b/examples/encoding-example/main.rs
@@ -10,7 +10,7 @@ use tycho_execution::encoding::{
         encoder_builders::TychoRouterEncoderBuilder,
         swap_encoder::swap_encoder_registry::SwapEncoderRegistry,
     },
-    models::{default_token, Solution, Swap},
+    models::{Solution, Swap},
 };
 
 fn main() {
@@ -42,8 +42,8 @@ fn main() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(usdc.clone()),
+        weth.clone(),
+        usdc.clone(),
     );
     // Split defines the fraction of the amount to be swapped. A value of 0 indicates 100% of
     // the amount or the total remaining balance. (0 is default, so no need to set it)
@@ -93,8 +93,8 @@ fn main() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(dai.clone()),
+        weth.clone(),
+        dai.clone(),
     )
     .with_split(0.5);
 
@@ -106,8 +106,8 @@ fn main() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
 
     let swap_dai_usdc = Swap::new(
@@ -116,8 +116,8 @@ fn main() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(dai.clone()),
-        default_token(usdc.clone()),
+        dai.clone(),
+        usdc.clone(),
     );
     let swap_wbtc_usdc = Swap::new(
         ProtocolComponent {
@@ -125,8 +125,8 @@ fn main() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdc.clone()),
+        wbtc.clone(),
+        usdc.clone(),
     );
     let complex_solution = solution.clone().with_swaps(vec![
         swap_weth_dai,

--- a/examples/uniswapx-encoding-example/main.rs
+++ b/examples/uniswapx-encoding-example/main.rs
@@ -7,7 +7,7 @@ use alloy::{
 };
 use num_bigint::{BigInt, BigUint};
 use tycho_common::{
-    models::{protocol::ProtocolComponent, token::Token, Chain},
+    models::{protocol::ProtocolComponent, Chain},
     Bytes,
 };
 use tycho_execution::encoding::{
@@ -73,10 +73,6 @@ fn main() {
     let usdc_addr = Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
     let usdt_addr = Bytes::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7").unwrap();
 
-    let dai = Token::new(&dai_addr, "DAI", 18, 0, &[], Chain::Ethereum, 100);
-    let usdc = Token::new(&usdc_addr, "USDC", 6, 0, &[], Chain::Ethereum, 100);
-    let usdt = Token::new(&usdt_addr, "USDT", 6, 0, &[], Chain::Ethereum, 100);
-
     let swap_dai_usdc = Swap::new(
         ProtocolComponent {
             id: "0x5777d92f208679DB4b9778590Fa3CAB3aC9e2168".to_string(),
@@ -89,8 +85,8 @@ fn main() {
             },
             ..Default::default()
         },
-        dai.clone(),
-        usdc.clone(),
+        dai_addr.clone(),
+        usdc_addr.clone(),
     );
     let swap_usdc_usdt = Swap::new(
         ProtocolComponent {
@@ -104,8 +100,8 @@ fn main() {
             },
             ..Default::default()
         },
-        usdc.clone(),
-        usdt.clone(),
+        usdc_addr.clone(),
+        usdt_addr.clone(),
     );
 
     // Then we create a solution object with the previous swaps

--- a/src/encoding/evm/group_swaps.rs
+++ b/src/encoding/evm/group_swaps.rs
@@ -50,7 +50,7 @@ pub fn group_swaps(swaps: &[Swap]) -> Vec<SwapGroup> {
 
         // Split 0 can also mean that the swap is the remaining part of a branch of splits,
         // so we need to check the last swap's out token as well
-        let no_split = swap.split() == 0.0 && swap.token_in().address == last_swap_out_token;
+        let no_split = swap.split() == 0.0 && *swap.token_in() == last_swap_out_token;
 
         if current_swap_protocol == last_swap_protocol && groupable_protocol && no_split {
             // Second or later groupable pool in a sequence of groupable pools. Merge to the
@@ -58,7 +58,7 @@ pub fn group_swaps(swaps: &[Swap]) -> Vec<SwapGroup> {
             if let Some(group) = current_group.as_mut() {
                 group.swaps.push(swap.clone());
                 // Update the output token of the current group.
-                group.token_out = swap.token_out().address.clone();
+                group.token_out = swap.token_out().clone();
             }
         } else {
             // Not second or later USV4 pool. Push the current group (if it exists) and then
@@ -67,15 +67,15 @@ pub fn group_swaps(swaps: &[Swap]) -> Vec<SwapGroup> {
                 grouped_swaps.push(group.clone());
             }
             current_group = Some(SwapGroup {
-                token_in: swap.token_in().address.clone(),
-                token_out: swap.token_out().address.clone(),
+                token_in: swap.token_in().clone(),
+                token_out: swap.token_out().clone(),
                 protocol_system: current_swap_protocol.clone(),
                 swaps: vec![swap.clone()],
                 split: swap.split(),
             });
         }
         last_swap_protocol = current_swap_protocol;
-        last_swap_out_token = swap.token_out().address.clone();
+        last_swap_out_token = swap.token_out().clone();
     }
     if let Some(group) = current_group.as_mut() {
         grouped_swaps.push(group.clone());
@@ -91,7 +91,7 @@ mod tests {
     use tycho_common::{models::protocol::ProtocolComponent, Bytes};
 
     use super::*;
-    use crate::encoding::models::{default_token, Swap};
+    use crate::encoding::models::Swap;
 
     fn weth() -> Bytes {
         Bytes::from(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").to_vec())
@@ -111,20 +111,20 @@ mod tests {
 
         let swap_weth_wbtc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
-            default_token(weth.clone()),
-            default_token(wbtc.clone()),
+            weth.clone(),
+            wbtc.clone(),
         );
 
         let swap_wbtc_usdc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
-            default_token(wbtc.clone()),
-            default_token(usdc.clone()),
+            wbtc.clone(),
+            usdc.clone(),
         );
 
         let swap_usdc_dai = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v2".to_string(), ..Default::default() },
-            default_token(usdc.clone()),
-            default_token(dai.clone()),
+            usdc.clone(),
+            dai.clone(),
         );
         let swaps = vec![swap_weth_wbtc.clone(), swap_wbtc_usdc.clone(), swap_usdc_dai.clone()];
         let grouped_swaps = group_swaps(&swaps);
@@ -167,27 +167,27 @@ mod tests {
 
         let swap_wbtc_weth = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
-            default_token(wbtc.clone()),
-            default_token(weth.clone()),
+            wbtc.clone(),
+            weth.clone(),
         );
         let swap_weth_usdc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
-            default_token(weth.clone()),
-            default_token(usdc.clone()),
+            weth.clone(),
+            usdc.clone(),
         )
         .with_split(0.5f64);
         let swap_weth_dai = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
-            default_token(weth.clone()),
-            default_token(dai.clone()),
+            weth.clone(),
+            dai.clone(),
         );
         // Split 0 represents the remaining 50%, but to avoid any rounding errors we set this to
         // 0 to signify "the remainder of the WETH value". It should still be very close to 50%
 
         let swap_dai_usdc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
-            default_token(dai.clone()),
-            default_token(usdc.clone()),
+            dai.clone(),
+            usdc.clone(),
         );
         let swaps = vec![
             swap_wbtc_weth.clone(),
@@ -244,8 +244,8 @@ mod tests {
                 protocol_system: "vm:balancer_v3".to_string(),
                 ..Default::default()
             },
-            default_token(weth.clone()),
-            default_token(wbtc.clone()),
+            weth.clone(),
+            wbtc.clone(),
         )
         .with_split(0.5f64);
 
@@ -254,18 +254,18 @@ mod tests {
                 protocol_system: "vm:balancer_v3".to_string(),
                 ..Default::default()
             },
-            default_token(wbtc.clone()),
-            default_token(usdc.clone()),
+            wbtc.clone(),
+            usdc.clone(),
         );
         let swap_weth_dai = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
-            default_token(weth.clone()),
-            default_token(dai.clone()),
+            weth.clone(),
+            dai.clone(),
         );
         let swap_dai_usdc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
-            default_token(dai.clone()),
-            default_token(usdc.clone()),
+            dai.clone(),
+            usdc.clone(),
         );
 
         let swaps = vec![
@@ -311,8 +311,8 @@ mod tests {
 
         let swap_weth_wbtc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
-            default_token(weth.clone()),
-            default_token(wbtc.clone()),
+            weth.clone(),
+            wbtc.clone(),
         );
 
         let swap_wbtc_usdc = Swap::new(
@@ -320,14 +320,14 @@ mod tests {
                 protocol_system: "uniswap_v4_hooks".to_string(),
                 ..Default::default()
             },
-            default_token(wbtc.clone()),
-            default_token(usdc.clone()),
+            wbtc.clone(),
+            usdc.clone(),
         );
 
         let swap_usdc_dai = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v2".to_string(), ..Default::default() },
-            default_token(usdc.clone()),
-            default_token(dai.clone()),
+            usdc.clone(),
+            dai.clone(),
         );
         let swaps = vec![swap_weth_wbtc.clone(), swap_wbtc_usdc.clone(), swap_usdc_dai.clone()];
         let grouped_swaps = group_swaps(&swaps);

--- a/src/encoding/evm/strategy_encoder/strategy_encoders.rs
+++ b/src/encoding/evm/strategy_encoder/strategy_encoders.rs
@@ -93,7 +93,7 @@ impl StrategyEncoder for SingleSwapStrategyEncoder {
         let mut initial_protocol_data: Vec<u8> = vec![];
         for swap in grouped_swap.swaps.iter() {
             let protocol_data = swap_encoder.encode_swap(swap, &encoding_context)?;
-            if encoding_context.group_token_in == *swap.token_in().address {
+            if encoding_context.group_token_in == *swap.token_in() {
                 initial_protocol_data = protocol_data;
             } else {
                 grouped_protocol_data.push(protocol_data);
@@ -193,7 +193,7 @@ impl StrategyEncoder for SequentialSwapStrategyEncoder {
             let mut initial_protocol_data: Vec<u8> = vec![];
             for swap in grouped_swap.swaps.iter() {
                 let protocol_data = swap_encoder.encode_swap(swap, &encoding_context)?;
-                if encoding_context.group_token_in == *swap.token_in().address {
+                if encoding_context.group_token_in == *swap.token_in() {
                     initial_protocol_data = protocol_data;
                 } else {
                     grouped_protocol_data.push(protocol_data);
@@ -331,7 +331,7 @@ impl StrategyEncoder for SplitSwapStrategyEncoder {
             let mut initial_protocol_data: Vec<u8> = vec![];
             for swap in grouped_swap.swaps.iter() {
                 let protocol_data = swap_encoder.encode_swap(swap, &encoding_context)?;
-                if encoding_context.group_token_in == *swap.token_in().address {
+                if encoding_context.group_token_in == *swap.token_in() {
                     initial_protocol_data = protocol_data;
                 } else {
                     grouped_protocol_data.push(protocol_data);
@@ -415,7 +415,7 @@ mod tests {
 
     mod single {
         use super::*;
-        use crate::encoding::models::{default_token, Swap};
+        use crate::encoding::models::Swap;
         #[test]
         fn test_single_swap_strategy_encoder() {
             // Performs a single swap from WETH to DAI on a USV2 pool, with no grouping
@@ -430,8 +430,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             );
             let swap_encoder_registry = get_swap_encoder_registry();
             let encoder =
@@ -468,7 +468,7 @@ mod tests {
 
     mod sequential {
         use super::*;
-        use crate::encoding::models::{default_token, Swap};
+        use crate::encoding::models::Swap;
 
         #[test]
         fn test_sequential_swap_strategy_encoder_no_permit2() {
@@ -486,8 +486,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(wbtc.clone()),
+                weth.clone(),
+                wbtc.clone(),
             );
             let swap_wbtc_usdc = Swap::new(
                 ProtocolComponent {
@@ -495,8 +495,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(wbtc.clone()),
-                default_token(usdc.clone()),
+                wbtc.clone(),
+                usdc.clone(),
             );
             let swap_encoder_registry = get_swap_encoder_registry();
             let encoder =
@@ -544,7 +544,7 @@ mod tests {
 
     mod split {
         use super::*;
-        use crate::encoding::models::{default_token, Swap};
+        use crate::encoding::models::Swap;
 
         #[test]
         fn test_split_input_cyclic_swap() {
@@ -575,8 +575,8 @@ mod tests {
                     },
                     ..Default::default()
                 },
-                default_token(usdc.clone()),
-                default_token(weth.clone()),
+                usdc.clone(),
+                weth.clone(),
             )
             .with_split(0.6f64);
 
@@ -596,8 +596,8 @@ mod tests {
                     },
                     ..Default::default()
                 },
-                default_token(usdc.clone()),
-                default_token(weth.clone()),
+                usdc.clone(),
+                weth.clone(),
             );
 
             // WETH -> USDC (Pool 2)
@@ -616,8 +616,8 @@ mod tests {
                     },
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(usdc.clone()),
+                weth.clone(),
+                usdc.clone(),
             );
             let swap_encoder_registry = get_swap_encoder_registry();
             let encoder = SplitSwapStrategyEncoder::new(
@@ -709,8 +709,8 @@ mod tests {
                     },
                     ..Default::default()
                 },
-                default_token(usdc.clone()),
-                default_token(weth.clone()),
+                usdc.clone(),
+                weth.clone(),
             );
 
             let swap_weth_usdc_v3_pool1 = Swap::new(
@@ -728,8 +728,8 @@ mod tests {
                     },
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(usdc.clone()),
+                weth.clone(),
+                usdc.clone(),
             )
             .with_split(0.6f64);
 
@@ -748,8 +748,8 @@ mod tests {
                     },
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(usdc.clone()),
+                weth.clone(),
+                usdc.clone(),
             );
 
             let swap_encoder_registry = get_swap_encoder_registry();

--- a/src/encoding/evm/strategy_encoder/strategy_validators.rs
+++ b/src/encoding/evm/strategy_encoder/strategy_validators.rs
@@ -22,11 +22,11 @@ pub trait SwapValidator {
         let mut all_tokens = HashSet::new();
         for swap in swaps {
             graph
-                .entry(&swap.token_in().address)
+                .entry(swap.token_in())
                 .or_default()
-                .insert(&swap.token_out().address);
-            all_tokens.insert(&swap.token_in().address);
-            all_tokens.insert(&swap.token_out().address);
+                .insert(swap.token_out());
+            all_tokens.insert(swap.token_in());
+            all_tokens.insert(swap.token_out());
         }
 
         // BFS from validation_given
@@ -98,7 +98,7 @@ impl SplitSwapValidator {
                 )));
             }
             swaps_by_token
-                .entry(&swap.token_in().address)
+                .entry(swap.token_in())
                 .or_default()
                 .push(swap);
         }
@@ -168,7 +168,7 @@ mod tests {
     use tycho_common::{models::protocol::ProtocolComponent, Bytes};
 
     use super::*;
-    use crate::encoding::models::{default_token, Swap};
+    use crate::encoding::models::Swap;
 
     #[test]
     fn test_validate_path_single_swap() {
@@ -181,8 +181,8 @@ mod tests {
                 protocol_system: "uniswap_v2".to_string(),
                 ..Default::default()
             },
-            default_token(weth.clone()),
-            default_token(dai.clone()),
+            weth.clone(),
+            dai.clone(),
         )];
         let result = validator.validate_swap_path(&swaps, &weth, &dai);
         assert_eq!(result, Ok(()));
@@ -201,8 +201,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             )
             .with_split(0.5f64),
             Swap::new(
@@ -211,8 +211,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(dai.clone()),
-                default_token(usdc.clone()),
+                dai.clone(),
+                usdc.clone(),
             ),
         ];
         let result = validator.validate_swap_path(&swaps, &weth, &usdc);
@@ -234,8 +234,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             )
             .with_split(0.5f64),
             // This swap is disconnected from the WETH->DAI path
@@ -245,8 +245,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(wbtc.clone()),
-                default_token(usdc.clone()),
+                wbtc.clone(),
+                usdc.clone(),
             ),
         ];
         let result = validator.validate_swap_path(&disconnected_swaps, &weth, &usdc);
@@ -269,8 +269,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(usdc.clone()),
-                default_token(weth.clone()),
+                usdc.clone(),
+                weth.clone(),
             ),
             Swap::new(
                 ProtocolComponent {
@@ -278,8 +278,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(usdc.clone()),
+                weth.clone(),
+                usdc.clone(),
             ),
         ];
 
@@ -301,8 +301,8 @@ mod tests {
                 protocol_system: "uniswap_v2".to_string(),
                 ..Default::default()
             },
-            default_token(weth.clone()),
-            default_token(dai.clone()),
+            weth.clone(),
+            dai.clone(),
         )
         .with_split(1.0)];
         let result = validator.validate_swap_path(&unreachable_swaps, &weth, &usdc);
@@ -337,8 +337,8 @@ mod tests {
                 protocol_system: "uniswap_v2".to_string(),
                 ..Default::default()
             },
-            default_token(weth.clone()),
-            default_token(dai.clone()),
+            weth.clone(),
+            dai.clone(),
         )];
         let result = validator.validate_split_percentages(&swaps);
         assert_eq!(result, Ok(()));
@@ -358,8 +358,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             )
             .with_split(0.5),
             Swap::new(
@@ -368,8 +368,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             )
             .with_split(0.3),
             Swap::new(
@@ -378,8 +378,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             ),
         ];
         assert!(validator
@@ -400,8 +400,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             )
             .with_split(0.7),
             Swap::new(
@@ -410,8 +410,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             )
             .with_split(0.3),
         ];
@@ -434,8 +434,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             ),
             Swap::new(
                 ProtocolComponent {
@@ -443,8 +443,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             )
             .with_split(0.5),
         ];
@@ -467,8 +467,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             )
             .with_split(0.6),
             Swap::new(
@@ -477,8 +477,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             )
             .with_split(0.5),
             Swap::new(
@@ -487,8 +487,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth.clone()),
-                default_token(dai.clone()),
+                weth.clone(),
+                dai.clone(),
             ),
         ];
         assert!(matches!(

--- a/src/encoding/evm/swap_encoder/balancer_v2.rs
+++ b/src/encoding/evm/swap_encoder/balancer_v2.rs
@@ -36,11 +36,8 @@ impl SwapEncoder for BalancerV2SwapEncoder {
         let component_id = AlloyBytes::from_str(&swap.component().id)
             .map_err(|_| EncodingError::FatalError("Invalid component ID".to_string()))?;
 
-        let args = (
-            bytes_to_address(&swap.token_in().address)?,
-            bytes_to_address(&swap.token_out().address)?,
-            component_id,
-        );
+        let args =
+            (bytes_to_address(swap.token_in())?, bytes_to_address(swap.token_out())?, component_id);
         Ok(args.abi_encode_packed())
     }
 
@@ -60,7 +57,7 @@ mod tests {
     use super::*;
     use crate::encoding::{
         evm::{swap_encoder::balancer_v2::BalancerV2SwapEncoder, utils::write_calldata_to_file},
-        models::{default_token, Swap},
+        models::Swap,
     };
     #[test]
     fn test_encode_balancer_v2() {
@@ -71,11 +68,7 @@ mod tests {
         };
         let token_in = Bytes::from("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
         let token_out = Bytes::from("0xba100000625a3754423978a60c9317c58a424e3D");
-        let swap = Swap::new(
-            balancer_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(balancer_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/swap_encoder/balancer_v3.rs
+++ b/src/encoding/evm/swap_encoder/balancer_v3.rs
@@ -37,11 +37,7 @@ impl SwapEncoder for BalancerV3SwapEncoder {
             EncodingError::FatalError("Invalid pool address for Balancer v3".to_string())
         })?;
 
-        let args = (
-            bytes_to_address(&swap.token_in().address)?,
-            bytes_to_address(&swap.token_out().address)?,
-            pool,
-        );
+        let args = (bytes_to_address(swap.token_in())?, bytes_to_address(swap.token_out())?, pool);
         Ok(args.abi_encode_packed())
     }
 
@@ -62,7 +58,7 @@ mod tests {
     use super::*;
     use crate::encoding::{
         evm::{swap_encoder::balancer_v3::BalancerV3SwapEncoder, utils::write_calldata_to_file},
-        models::default_token,
+        models::Swap,
     };
 
     #[test]
@@ -74,11 +70,7 @@ mod tests {
         };
         let token_in = Bytes::from("0x7bc3485026ac48b6cf9baf0a377477fff5703af8");
         let token_out = Bytes::from("0xc71ea051a5f82c67adcf634c36ffe6334793d24c");
-        let swap = Swap::new(
-            balancer_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(balancer_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/swap_encoder/bebop.rs
+++ b/src/encoding/evm/swap_encoder/bebop.rs
@@ -47,8 +47,8 @@ impl SwapEncoder for BebopSwapEncoder {
         swap: &Swap,
         encoding_context: &EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
-        let token_in = bytes_to_address(&swap.token_in().address)?;
-        let token_out = bytes_to_address(&swap.token_out().address)?;
+        let token_in = bytes_to_address(swap.token_in())?;
+        let token_out = bytes_to_address(swap.token_out())?;
 
         let protocol_state = swap
             .protocol_state()
@@ -68,8 +68,8 @@ impl SwapEncoder for BebopSwapEncoder {
                 .ok_or(EncodingError::FatalError(
                     "Estimated amount in is mandatory for a Bebop swap".to_string(),
                 ))?;
-            let token_in = swap.token_in().address.clone();
-            let token_out = swap.token_out().address.clone();
+            let token_in = swap.token_in().clone();
+            let token_out = swap.token_out().clone();
             let router_address = encoding_context
                 .router_address
                 .clone()
@@ -144,9 +144,8 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{
-        evm::{swap_encoder::bebop::BebopSwapEncoder, testing_utils::MockRFQState},
-        models::default_token,
+    use crate::encoding::evm::{
+        swap_encoder::bebop::BebopSwapEncoder, testing_utils::MockRFQState,
     };
 
     #[test]
@@ -179,13 +178,9 @@ mod tests {
         let token_in = Bytes::from("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
         let token_out = Bytes::from("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"); // WETH
 
-        let swap = Swap::new(
-            bebop_component,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        )
-        .with_estimated_amount_in(BigUint::from_str("3000000000").unwrap())
-        .with_protocol_state(Arc::new(bebop_state));
+        let swap = Swap::new(bebop_component, token_in.clone(), token_out.clone())
+            .with_estimated_amount_in(BigUint::from_str("3000000000").unwrap())
+            .with_protocol_state(Arc::new(bebop_state));
 
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),

--- a/src/encoding/evm/swap_encoder/curve.rs
+++ b/src/encoding/evm/swap_encoder/curve.rs
@@ -145,15 +145,15 @@ impl SwapEncoder for CurveSwapEncoder {
         _encoding_context: &EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
         let native_token_curve_address = Address::from_slice(&self.native_token_curve_address);
-        let token_in = if *swap.token_in().address == self.native_token_address {
+        let token_in = if *swap.token_in() == self.native_token_address {
             native_token_curve_address
         } else {
-            bytes_to_address(&swap.token_in().address)?
+            bytes_to_address(swap.token_in())?
         };
-        let token_out = if *swap.token_out().address == self.native_token_address {
+        let token_out = if *swap.token_out() == self.native_token_address {
             native_token_curve_address
         } else {
-            bytes_to_address(&swap.token_out().address)?
+            bytes_to_address(swap.token_out())?
         };
 
         let component_address = Address::from_str(&swap.component().id)
@@ -203,7 +203,7 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{evm::swap_encoder::curve::CurveSwapEncoder, models::default_token};
+    use crate::encoding::{evm::swap_encoder::curve::CurveSwapEncoder, models::Swap};
 
     fn curve_config() -> Option<HashMap<String, String>> {
         Some(HashMap::from([
@@ -279,8 +279,8 @@ mod tests {
                 static_attributes,
                 ..Default::default()
             },
-            default_token(Bytes::from(token_in)),
-            default_token(Bytes::from(token_out)),
+            Bytes::from(token_in),
+            Bytes::from(token_out),
         );
 
         let encoder =
@@ -316,11 +316,7 @@ mod tests {
         };
         let token_in = Bytes::from("0x6B175474E89094C44Da98b954EedeAC495271d0F");
         let token_out = Bytes::from("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
-        let swap = Swap::new(
-            curve_tri_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(curve_tri_pool, token_in.clone(), token_out.clone());
 
         let encoding_context = EncodingContext {
             router_address: None,
@@ -377,11 +373,7 @@ mod tests {
         };
         let token_in = Bytes::from("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
         let token_out = Bytes::from("0x4c9EDD5852cd905f086C759E8383e09bff1E68B3");
-        let swap = Swap::new(
-            curve_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(curve_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: None,
             group_token_in: token_in.clone(),
@@ -438,11 +430,7 @@ mod tests {
         };
         let token_in = Bytes::from("0x0000000000000000000000000000000000000000");
         let token_out = Bytes::from("0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84");
-        let swap = Swap::new(
-            curve_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(curve_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: None,
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/swap_encoder/ekubo.rs
+++ b/src/encoding/evm/swap_encoder/ekubo.rs
@@ -55,11 +55,11 @@ impl SwapEncoder for EkuboSwapEncoder {
 
         let mut encoded = vec![];
 
-        if encoding_context.group_token_in == *swap.token_in().address {
-            encoded.extend(bytes_to_address(&swap.token_in().address)?);
+        if encoding_context.group_token_in == *swap.token_in() {
+            encoded.extend(bytes_to_address(swap.token_in())?);
         }
 
-        encoded.extend(bytes_to_address(&swap.token_out().address)?);
+        encoded.extend(bytes_to_address(swap.token_out())?);
         encoded.extend((extension, fee, tick_spacing).abi_encode_packed());
 
         Ok(encoded)
@@ -80,9 +80,8 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{
-        evm::{swap_encoder::ekubo::EkuboSwapEncoder, utils::write_calldata_to_file},
-        models::default_token,
+    use crate::encoding::evm::{
+        swap_encoder::ekubo::EkuboSwapEncoder, utils::write_calldata_to_file,
     };
 
     #[test]
@@ -98,8 +97,7 @@ mod tests {
 
         let component = ProtocolComponent { static_attributes, ..Default::default() };
 
-        let swap =
-            Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(component, token_in.clone(), token_out.clone());
 
         let encoding_context = EncodingContext {
             group_token_in: token_in.clone(),
@@ -154,8 +152,8 @@ mod tests {
                 ]),
                 ..Default::default()
             },
-            default_token(group_token_in.clone()),
-            default_token(intermediary_token.clone()),
+            group_token_in.clone(),
+            intermediary_token.clone(),
         );
 
         let second_swap = Swap::new(
@@ -168,8 +166,8 @@ mod tests {
                 ]),
                 ..Default::default()
             },
-            default_token(intermediary_token.clone()),
-            default_token(group_token_out.clone()),
+            intermediary_token.clone(),
+            group_token_out.clone(),
         );
 
         let first_encoded_swap = encoder

--- a/src/encoding/evm/swap_encoder/ekubo_v3.rs
+++ b/src/encoding/evm/swap_encoder/ekubo_v3.rs
@@ -54,11 +54,11 @@ impl SwapEncoder for EkuboV3SwapEncoder {
 
         let mut encoded = vec![];
 
-        if encoding_context.group_token_in == *swap.token_in().address {
-            encoded.extend(bytes_to_address(&swap.token_in().address)?);
+        if encoding_context.group_token_in == *swap.token_in() {
+            encoded.extend(bytes_to_address(swap.token_in())?);
         }
 
-        encoded.extend(bytes_to_address(&swap.token_out().address)?);
+        encoded.extend(bytes_to_address(swap.token_out())?);
         encoded.extend((extension, fee, pool_type_config).abi_encode_packed());
 
         Ok(encoded)
@@ -81,7 +81,7 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{evm::utils::write_calldata_to_file, models::default_token};
+    use crate::encoding::evm::utils::write_calldata_to_file;
 
     #[test]
     fn test_encode_swap_simple() {
@@ -96,8 +96,7 @@ mod tests {
 
         let component = ProtocolComponent { static_attributes, ..Default::default() };
 
-        let swap =
-            Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(component, token_in.clone(), token_out.clone());
 
         let encoding_context = EncodingContext {
             group_token_in: token_in.clone(),
@@ -152,8 +151,8 @@ mod tests {
                 ]),
                 ..Default::default()
             },
-            default_token(group_token_in.clone()),
-            default_token(intermediary_token.clone()),
+            group_token_in.clone(),
+            intermediary_token.clone(),
         );
 
         let second_swap = Swap::new(
@@ -165,8 +164,8 @@ mod tests {
                 ]),
                 ..Default::default()
             },
-            default_token(intermediary_token.clone()),
-            default_token(group_token_out.clone()),
+            intermediary_token.clone(),
+            group_token_out.clone(),
         );
 
         let first_encoded_swap = encoder

--- a/src/encoding/evm/swap_encoder/erc_4626.rs
+++ b/src/encoding/evm/swap_encoder/erc_4626.rs
@@ -32,7 +32,7 @@ impl SwapEncoder for ERC4626SwapEncoder {
         let component_id = AlloyBytes::from_str(&swap.component().id)
             .map_err(|_| EncodingError::FatalError("Invalid component ID".to_string()))?;
 
-        let args = (bytes_to_address(&swap.token_in().address)?, component_id);
+        let args = (bytes_to_address(swap.token_in())?, component_id);
         Ok(args.abi_encode_packed())
     }
 
@@ -50,7 +50,7 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::models::default_token;
+
     #[test]
     fn test_encode_erc4626_deposit() {
         // WETH -> (spETH) -> spETH
@@ -61,11 +61,7 @@ mod tests {
         };
         let token_in = Bytes::from("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
         let token_out = Bytes::from("0xfE6eb3b609a7C8352A241f7F3A21CEA4e9209B8f");
-        let swap = Swap::new(
-            sp_eth_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(sp_eth_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),
             group_token_in: token_in.clone(),
@@ -105,11 +101,7 @@ mod tests {
         };
         let token_in = Bytes::from("0xfE6eb3b609a7C8352A241f7F3A21CEA4e9209B8f");
         let token_out = Bytes::from("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
-        let swap = Swap::new(
-            sp_eth_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(sp_eth_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/swap_encoder/etherfi.rs
+++ b/src/encoding/evm/swap_encoder/etherfi.rs
@@ -65,21 +65,15 @@ impl SwapEncoder for EtherfiSwapEncoder {
         swap: &Swap,
         _encoding_context: &EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
-        let direction = if *swap.token_in().address == self.eeth_address &&
-            *swap.token_out().address == self.eth_address
+        let direction = if *swap.token_in() == self.eeth_address &&
+            *swap.token_out() == self.eth_address
         {
             EtherfiDirection::EethToEth
-        } else if *swap.token_in().address == self.eth_address &&
-            *swap.token_out().address == self.eeth_address
-        {
+        } else if *swap.token_in() == self.eth_address && *swap.token_out() == self.eeth_address {
             EtherfiDirection::EthToEeth
-        } else if *swap.token_in().address == self.eeth_address &&
-            *swap.token_out().address == self.weeth_address
-        {
+        } else if *swap.token_in() == self.eeth_address && *swap.token_out() == self.weeth_address {
             EtherfiDirection::EethToWeeth
-        } else if *swap.token_in().address == self.weeth_address &&
-            *swap.token_out().address == self.eeth_address
-        {
+        } else if *swap.token_in() == self.weeth_address && *swap.token_out() == self.eeth_address {
             EtherfiDirection::WeethToEeth
         } else {
             return Err(EncodingError::InvalidInput("Combination not allowed".to_owned()))
@@ -105,7 +99,6 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::models::default_token;
 
     const EETH_ADDRESS: &str = "0x35fA164735182de50811E8e2E824cFb9B6118ac2";
     const WEETH_ADDRESS: &str = "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee";
@@ -144,8 +137,7 @@ mod tests {
         };
         let token_in = Bytes::from(EETH_ADDRESS);
         let token_out = Bytes::from("0x0000000000000000000000000000000000000000");
-        let swap =
-            Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(component, token_in.clone(), token_out.clone());
         let encoded_swap = encoder()
             .encode_swap(&swap, &encoding_context(&token_in, &token_out))
             .unwrap();
@@ -162,8 +154,7 @@ mod tests {
         };
         let token_in = Bytes::from("0x0000000000000000000000000000000000000000");
         let token_out = Bytes::from(EETH_ADDRESS);
-        let swap =
-            Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(component, token_in.clone(), token_out.clone());
         let encoded_swap = encoder()
             .encode_swap(&swap, &encoding_context(&token_in, &token_out))
             .unwrap();
@@ -180,8 +171,7 @@ mod tests {
         };
         let token_in = Bytes::from(EETH_ADDRESS);
         let token_out = Bytes::from(WEETH_ADDRESS);
-        let swap =
-            Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(component, token_in.clone(), token_out.clone());
         let encoded_swap = encoder()
             .encode_swap(&swap, &encoding_context(&token_in, &token_out))
             .unwrap();
@@ -198,8 +188,7 @@ mod tests {
         };
         let token_in = Bytes::from(WEETH_ADDRESS);
         let token_out = Bytes::from(EETH_ADDRESS);
-        let swap =
-            Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(component, token_in.clone(), token_out.clone());
         let encoded_swap = encoder()
             .encode_swap(&swap, &encoding_context(&token_in, &token_out))
             .unwrap();
@@ -216,8 +205,7 @@ mod tests {
         };
         let token_in = Bytes::from(WEETH_ADDRESS);
         let token_out = Bytes::from("0x0000000000000000000000000000000000000000");
-        let swap =
-            Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(component, token_in.clone(), token_out.clone());
         let encoded_swap = encoder().encode_swap(&swap, &encoding_context(&token_in, &token_out));
 
         assert!(encoded_swap.is_err());

--- a/src/encoding/evm/swap_encoder/fluid_v1.rs
+++ b/src/encoding/evm/swap_encoder/fluid_v1.rs
@@ -44,10 +44,10 @@ impl SwapEncoder for FluidV1SwapEncoder {
 
         let args = (
             dex_address,
-            self.coerce_native_address(&swap.token_in().address) <
-                self.coerce_native_address(&swap.token_out().address),
-            bytes_to_address(&swap.token_out().address)?,
-            swap.token_in().address == self.chain.native_token().address,
+            self.coerce_native_address(swap.token_in()) <
+                self.coerce_native_address(swap.token_out()),
+            bytes_to_address(swap.token_out())?,
+            *swap.token_in() == self.chain.native_token().address,
         );
         Ok(args.abi_encode_packed())
     }
@@ -77,7 +77,7 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{evm::swap_encoder::fluid_v1::FluidV1SwapEncoder, models::default_token};
+    use crate::encoding::evm::swap_encoder::fluid_v1::FluidV1SwapEncoder;
 
     #[test]
     fn test_encode_fluid_v1() {
@@ -89,8 +89,7 @@ mod tests {
         };
         let token_in = Bytes::from("0x9d39a5de30e57443bff2a8307a4256c8797a3497");
         let token_out = Bytes::from("0xdac17f958d2ee523a2206206994597c13d831ec7");
-        let swap =
-            Swap::new(fluid_dex, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(fluid_dex, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::default()),
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/swap_encoder/hashflow.rs
+++ b/src/encoding/evm/swap_encoder/hashflow.rs
@@ -66,8 +66,8 @@ impl SwapEncoder for HashflowSwapEncoder {
                     .as_indicatively_priced()?
                     .request_signed_quote(GetAmountOutParams {
                         amount_in,
-                        token_in: swap.token_in().address.clone(),
-                        token_out: swap.token_out().address.clone(),
+                        token_in: swap.token_in().clone(),
+                        token_out: swap.token_out().clone(),
                         sender: sender.clone(),
                         receiver: sender,
                     })
@@ -127,7 +127,7 @@ mod test {
             swap_encoder::hashflow::HashflowSwapEncoder, testing_utils::MockRFQState,
             utils::biguint_to_u256,
         },
-        models::{default_token, Swap},
+        models::Swap,
     };
 
     fn hashflow_config() -> Option<HashMap<String, String>> {
@@ -149,12 +149,8 @@ mod test {
         let token_in = Bytes::from("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
         let token_out = Bytes::from("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"); // WETH
 
-        let swap = Swap::new(
-            hashflow_component,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        )
-        .with_estimated_amount_in(BigUint::from_str("3000000000").unwrap());
+        let swap = Swap::new(hashflow_component, token_in.clone(), token_out.clone())
+            .with_estimated_amount_in(BigUint::from_str("3000000000").unwrap());
 
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),
@@ -241,13 +237,9 @@ mod test {
         let token_in = Bytes::from("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
         let token_out = Bytes::from("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"); // WETH
 
-        let swap = Swap::new(
-            hashflow_component,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        )
-        .with_estimated_amount_in(BigUint::from_str("3000000000").unwrap())
-        .with_protocol_state(Arc::new(hashflow_state));
+        let swap = Swap::new(hashflow_component, token_in.clone(), token_out.clone())
+            .with_estimated_amount_in(BigUint::from_str("3000000000").unwrap())
+            .with_protocol_state(Arc::new(hashflow_state));
 
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),

--- a/src/encoding/evm/swap_encoder/maverick_v2.rs
+++ b/src/encoding/evm/swap_encoder/maverick_v2.rs
@@ -36,11 +36,8 @@ impl SwapEncoder for MaverickV2SwapEncoder {
         let component_id = AlloyBytes::from_str(&swap.component().id)
             .map_err(|_| EncodingError::FatalError("Invalid component ID".to_string()))?;
 
-        let args = (
-            component_id,
-            bytes_to_address(&swap.token_in().address)?,
-            bytes_to_address(&swap.token_out().address)?,
-        );
+        let args =
+            (component_id, bytes_to_address(swap.token_in())?, bytes_to_address(swap.token_out())?);
         Ok(args.abi_encode_packed())
     }
 
@@ -58,9 +55,8 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{
-        evm::{swap_encoder::maverick_v2::MaverickV2SwapEncoder, utils::write_calldata_to_file},
-        models::default_token,
+    use crate::encoding::evm::{
+        swap_encoder::maverick_v2::MaverickV2SwapEncoder, utils::write_calldata_to_file,
     };
     #[test]
     fn test_encode_maverick_v2() {
@@ -72,11 +68,7 @@ mod tests {
         };
         let token_in = Bytes::from("0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f");
         let token_out = Bytes::from("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
-        let swap = Swap::new(
-            maverick_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(maverick_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::default()),
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/swap_encoder/rocketpool.rs
+++ b/src/encoding/evm/swap_encoder/rocketpool.rs
@@ -41,7 +41,7 @@ impl SwapEncoder for RocketpoolSwapEncoder {
         swap: &Swap,
         _encoding_context: &EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
-        let is_deposit = *swap.token_in().address == self.native_token_address;
+        let is_deposit = *swap.token_in() == self.native_token_address;
 
         let args = is_deposit;
 
@@ -63,9 +63,8 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{
-        evm::{swap_encoder::rocketpool::RocketpoolSwapEncoder, utils::write_calldata_to_file},
-        models::default_token,
+    use crate::encoding::evm::{
+        swap_encoder::rocketpool::RocketpoolSwapEncoder, utils::write_calldata_to_file,
     };
     #[test]
     fn test_encode_rocketpool_deposit() {
@@ -77,11 +76,7 @@ mod tests {
         };
         let token_in = Bytes::from("0x0000000000000000000000000000000000000000");
         let token_out = Bytes::from("0xae78736Cd615f374D3085123A210448E74Fc6393");
-        let swap = Swap::new(
-            rocketpool_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(rocketpool_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::default()),
             group_token_in: token_in.clone(),
@@ -114,11 +109,7 @@ mod tests {
         };
         let token_in = Bytes::from("0xae78736Cd615f374D3085123A210448E74Fc6393");
         let token_out = Bytes::from("0x0000000000000000000000000000000000000000");
-        let swap = Swap::new(
-            rocketpool_pool,
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-        );
+        let swap = Swap::new(rocketpool_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::default()),
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/swap_encoder/slipstreams.rs
+++ b/src/encoding/evm/swap_encoder/slipstreams.rs
@@ -39,8 +39,8 @@ impl SwapEncoder for SlipstreamsSwapEncoder {
         swap: &Swap,
         _encoding_context: &EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
-        let token_in_address = bytes_to_address(&swap.token_in().address)?;
-        let token_out_address = bytes_to_address(&swap.token_out().address)?;
+        let token_in_address = bytes_to_address(swap.token_in())?;
+        let token_out_address = bytes_to_address(swap.token_out())?;
 
         let zero_to_one = Self::get_zero_to_one(token_in_address, token_out_address);
         let component_id = Address::from_str(&swap.component().id).map_err(|_| {

--- a/src/encoding/evm/swap_encoder/uniswap_v2.rs
+++ b/src/encoding/evm/swap_encoder/uniswap_v2.rs
@@ -35,8 +35,8 @@ impl SwapEncoder for UniswapV2SwapEncoder {
         swap: &Swap,
         _encoding_context: &EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
-        let token_in_address = bytes_to_address(&swap.token_in().address)?;
-        let token_out_address = bytes_to_address(&swap.token_out().address)?;
+        let token_in_address = bytes_to_address(swap.token_in())?;
+        let token_out_address = bytes_to_address(swap.token_out())?;
         let component_id = Address::from_str(&swap.component().id)
             .map_err(|_| EncodingError::FatalError("Invalid USV2 component id".to_string()))?;
 
@@ -60,7 +60,7 @@ mod tests {
     use super::*;
     use crate::encoding::{
         evm::{swap_encoder::uniswap_v2::UniswapV2SwapEncoder, utils::write_calldata_to_file},
-        models::{default_token, Swap},
+        models::Swap,
     };
     #[test]
     fn test_encode_uniswap_v2() {
@@ -71,8 +71,7 @@ mod tests {
 
         let token_in = Bytes::from("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
         let token_out = Bytes::from("0x6b175474e89094c44da98b954eedeac495271d0f");
-        let swap =
-            Swap::new(usv2_pool, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(usv2_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/swap_encoder/uniswap_v3.rs
+++ b/src/encoding/evm/swap_encoder/uniswap_v3.rs
@@ -38,8 +38,8 @@ impl SwapEncoder for UniswapV3SwapEncoder {
         swap: &Swap,
         _encoding_context: &EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
-        let token_in_address = bytes_to_address(&swap.token_in().address)?;
-        let token_out_address = bytes_to_address(&swap.token_out().address)?;
+        let token_in_address = bytes_to_address(swap.token_in())?;
+        let token_out_address = bytes_to_address(swap.token_out())?;
 
         let zero_to_one = Self::get_zero_to_one(token_in_address, token_out_address);
         let component_id = Address::from_str(&swap.component().id)
@@ -69,10 +69,7 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{
-        evm::swap_encoder::uniswap_v3::UniswapV3SwapEncoder,
-        models::{default_token, Swap},
-    };
+    use crate::encoding::{evm::swap_encoder::uniswap_v3::UniswapV3SwapEncoder, models::Swap};
     #[test]
     fn test_encode_uniswap_v3() {
         let fee = BigInt::from(500);
@@ -87,8 +84,7 @@ mod tests {
         };
         let token_in = Bytes::from("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
         let token_out = Bytes::from("0x6b175474e89094c44da98b954eedeac495271d0f");
-        let swap =
-            Swap::new(usv3_pool, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(usv3_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/swap_encoder/uniswap_v4.rs
+++ b/src/encoding/evm/swap_encoder/uniswap_v4.rs
@@ -175,9 +175,9 @@ impl SwapEncoder for UniswapV4SwapEncoder {
         let hook_data_length = (hook_data.len() as u16).to_be_bytes();
 
         // Early check if this is not the first swap
-        if encoding_context.group_token_in != *swap.token_in().address {
+        if encoding_context.group_token_in != *swap.token_in() {
             return Ok((
-                bytes_to_address(&swap.token_out().address)?,
+                bytes_to_address(swap.token_out())?,
                 pool_fee_u24,
                 pool_tick_spacing_u24,
                 hook_address,
@@ -188,8 +188,8 @@ impl SwapEncoder for UniswapV4SwapEncoder {
         }
 
         // This is the first swap, compute all necessary values
-        let token_in_address = bytes_to_address(&swap.token_in().address)?;
-        let token_out_address = bytes_to_address(&swap.token_out().address)?;
+        let token_in_address = bytes_to_address(swap.token_in())?;
+        let token_out_address = bytes_to_address(swap.token_out())?;
         let group_token_in_address = bytes_to_address(&encoding_context.group_token_in)?;
         let group_token_out_address = bytes_to_address(&encoding_context.group_token_out)?;
 
@@ -249,7 +249,7 @@ mod tests {
     use super::*;
     use crate::encoding::{
         evm::utils::{ple_encode, write_calldata_to_file},
-        models::{default_token, Swap},
+        models::Swap,
     };
 
     #[test]
@@ -270,8 +270,7 @@ mod tests {
             static_attributes,
             ..Default::default()
         };
-        let swap =
-            Swap::new(usv4_pool, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(usv4_pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             // Same as the executor address
             router_address: Some(Bytes::from("0x5615deb798bb3e4dfa0139dfa1b3d433cc23b72f")),
@@ -333,8 +332,7 @@ mod tests {
             ..Default::default()
         };
 
-        let swap =
-            Swap::new(usv4_pool, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(usv4_pool, token_in.clone(), token_out.clone());
 
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::zero(20)),
@@ -422,16 +420,10 @@ mod tests {
             ..Default::default()
         };
 
-        let initial_swap = Swap::new(
-            usde_usdt_component,
-            default_token(usde_address.clone()),
-            default_token(usdt_address.clone()),
-        );
-        let second_swap = Swap::new(
-            usdt_wbtc_component,
-            default_token(usdt_address.clone()),
-            default_token(wbtc_address.clone()),
-        );
+        let initial_swap =
+            Swap::new(usde_usdt_component, usde_address.clone(), usdt_address.clone());
+        let second_swap =
+            Swap::new(usdt_wbtc_component, usdt_address.clone(), wbtc_address.clone());
 
         let encoder = UniswapV4SwapEncoder::new(
             Bytes::from("0xF62849F9A0B5Bf2913b396098F7c7019b51A820a"),
@@ -584,16 +576,8 @@ mod tests {
                 ..Default::default()
             };
 
-            let first_swap = Swap::new(
-                usdc_weth_pool,
-                default_token(usdc_address.clone()),
-                default_token(weth_address.clone()),
-            );
-            let second_swap = Swap::new(
-                weth_usdt_pool,
-                default_token(weth_address.clone()),
-                default_token(usdt_address.clone()),
-            );
+            let first_swap = Swap::new(usdc_weth_pool, usdc_address.clone(), weth_address.clone());
+            let second_swap = Swap::new(weth_usdt_pool, weth_address.clone(), usdt_address.clone());
 
             // Encoder reads Angstrom config from environment variables:
             // - ANGSTROM_API_KEY (required)

--- a/src/encoding/evm/swap_encoder/weth.rs
+++ b/src/encoding/evm/swap_encoder/weth.rs
@@ -35,7 +35,7 @@ impl SwapEncoder for WethSwapEncoder {
         swap: &Swap,
         _encoding_context: &EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
-        let is_wrapping = *swap.token_in().address == self.native_token_address;
+        let is_wrapping = *swap.token_in() == self.native_token_address;
         Ok(is_wrapping.abi_encode_packed())
     }
 
@@ -53,7 +53,7 @@ mod tests {
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{evm::utils::write_calldata_to_file, models::default_token};
+    use crate::encoding::evm::utils::write_calldata_to_file;
     #[test]
     fn test_encode_weth_wrapping() {
         // ETH -> (weth) -> wETH
@@ -61,8 +61,7 @@ mod tests {
             ProtocolComponent { protocol_system: String::from("weth"), ..Default::default() };
         let token_in = Bytes::from("0x0000000000000000000000000000000000000000");
         let token_out = Bytes::from("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
-        let swap =
-            Swap::new(pool, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::default()),
             group_token_in: token_in.clone(),
@@ -95,8 +94,7 @@ mod tests {
         };
         let token_in = Bytes::from("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
         let token_out = Bytes::from("0x0000000000000000000000000000000000000000");
-        let swap =
-            Swap::new(pool, default_token(token_in.clone()), default_token(token_out.clone()));
+        let swap = Swap::new(pool, token_in.clone(), token_out.clone());
         let encoding_context = EncodingContext {
             router_address: Some(Bytes::default()),
             group_token_in: token_in.clone(),

--- a/src/encoding/evm/tycho_encoders.rs
+++ b/src/encoding/evm/tycho_encoders.rs
@@ -118,9 +118,7 @@ impl TychoRouterEncoder {
         let mut new_swaps: Vec<Swap> = Vec::with_capacity(swaps.len());
 
         // Check if we need to add a wrapping swap at the beginning of the solution
-        if let Some(s) =
-            self._wrapping_bridge(solution.token_in(), &swaps[0].token_in().address, chain)
-        {
+        if let Some(s) = self._wrapping_bridge(solution.token_in(), swaps[0].token_in(), chain) {
             new_swaps.push(s);
         }
 
@@ -129,8 +127,8 @@ impl TychoRouterEncoder {
         for i in 0..swaps.len() {
             new_swaps.push(swaps[i].clone());
             if i + 1 < swaps.len() {
-                let token_out = &swaps[i].token_out().address;
-                let token_in = &swaps[i + 1].token_in().address;
+                let token_out = swaps[i].token_out();
+                let token_in = swaps[i + 1].token_in();
                 if let Some(s) = self._wrapping_bridge(token_out, token_in, chain) {
                     new_swaps.push(s);
                 }
@@ -140,7 +138,7 @@ impl TychoRouterEncoder {
         // Check if we need to add an unwrapping swap at the end of the solution
         if let Some(last_swap) = swaps.last() {
             if let Some(s) =
-                self._wrapping_bridge(&last_swap.token_out().address, solution.token_out(), chain)
+                self._wrapping_bridge(last_swap.token_out(), solution.token_out(), chain)
             {
                 new_swaps.push(s);
             }
@@ -158,14 +156,14 @@ impl TychoRouterEncoder {
         if token_a == &weth.address && token_b == &eth.address {
             Some(Swap::new(
                 ProtocolComponent { protocol_system: "weth".to_string(), ..Default::default() },
-                weth,
-                eth,
+                weth.address.clone(),
+                eth.address.clone(),
             ))
         } else if token_a == &eth.address && token_b == &weth.address {
             Some(Swap::new(
                 ProtocolComponent { protocol_system: "weth".to_string(), ..Default::default() },
-                eth,
-                weth,
+                eth.address.clone(),
+                weth.address.clone(),
             ))
         } else {
             None
@@ -203,18 +201,18 @@ impl TychoEncoder for TychoRouterEncoder {
         for (i, swap) in swaps.iter().enumerate() {
             // so we don't count the split tokens more than once
             if swap.split() != 0.0 {
-                if !split_tokens_already_considered.contains(&swap.token_in().address) {
-                    solution_tokens.push(&swap.token_in().address);
-                    split_tokens_already_considered.insert(&swap.token_in().address);
+                if !split_tokens_already_considered.contains(swap.token_in()) {
+                    solution_tokens.push(swap.token_in());
+                    split_tokens_already_considered.insert(swap.token_in());
                 }
             } else {
                 // it might be the last swap of the split or a regular swap
-                if !split_tokens_already_considered.contains(&swap.token_in().address) {
-                    solution_tokens.push(&swap.token_in().address);
+                if !split_tokens_already_considered.contains(swap.token_in()) {
+                    solution_tokens.push(swap.token_in());
                 }
             }
             if i == swaps.len() - 1 {
-                solution_tokens.push(&swap.token_out().address);
+                solution_tokens.push(swap.token_out());
             }
         }
 
@@ -226,7 +224,7 @@ impl TychoEncoder for TychoRouterEncoder {
                 .len()
         {
             if let Some(last_swap) = swaps.last() {
-                if *swaps[0].token_in().address != *last_swap.token_out().address {
+                if *swaps[0].token_in() != *last_swap.token_out() {
                     return Err(EncodingError::FatalError(
                         "Cyclical swaps are only allowed if they are the first and last token of a solution".to_string(),
                     ));
@@ -289,7 +287,7 @@ impl TychoExecutorEncoder {
         let mut initial_protocol_data: Vec<u8> = vec![];
         for swap in grouped_swap.swaps.iter() {
             let protocol_data = swap_encoder.encode_swap(swap, &encoding_context)?;
-            if encoding_context.group_token_in == *swap.token_in().address {
+            if encoding_context.group_token_in == *swap.token_in() {
                 initial_protocol_data = protocol_data;
             } else {
                 grouped_protocol_data.push(protocol_data);
@@ -338,7 +336,7 @@ mod tests {
     use tycho_common::models::{protocol::ProtocolComponent, Chain};
 
     use super::*;
-    use crate::encoding::models::{default_token, Swap};
+    use crate::encoding::models::Swap;
 
     fn dai() -> Bytes {
         Bytes::from_str("0x6b175474e89094c44da98b954eedeac495271d0f").unwrap()
@@ -381,8 +379,8 @@ mod tests {
                 static_attributes: static_attributes_usdc_eth,
                 ..Default::default()
             },
-            default_token(usdc().clone()),
-            default_token(eth().clone()),
+            usdc().clone(),
+            eth().clone(),
         )
     }
 
@@ -400,8 +398,8 @@ mod tests {
                 static_attributes: static_attributes_eth_pepe,
                 ..Default::default()
             },
-            default_token(eth().clone()),
-            default_token(pepe().clone()),
+            eth().clone(),
+            pepe().clone(),
         )
     }
 
@@ -463,8 +461,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(dai().clone()),
-                default_token(usdc().clone()),
+                dai().clone(),
+                usdc().clone(),
             );
 
             let swap_weth_dai = Swap::new(
@@ -473,8 +471,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth().clone()),
-                default_token(dai().clone()),
+                weth().clone(),
+                dai().clone(),
             );
 
             let solution = Solution::new(
@@ -489,8 +487,8 @@ mod tests {
 
             let solution = encoder.add_weth_swaps(&solution, &encoder.chain);
             assert_eq!(solution.swaps().len(), 4);
-            assert_eq!(solution.swaps()[2].token_in().address, eth());
-            assert_eq!(solution.swaps()[2].token_out().address, weth());
+            assert_eq!(solution.swaps()[2].token_in(), &eth());
+            assert_eq!(solution.swaps()[2].token_out(), &weth());
             assert_eq!(
                 solution.swaps()[2]
                     .component()
@@ -512,8 +510,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(weth().clone()),
-                default_token(dai().clone()),
+                weth().clone(),
+                dai().clone(),
             );
 
             let solution = Solution::new(
@@ -528,8 +526,8 @@ mod tests {
 
             let solution = encoder.add_weth_swaps(&solution, &encoder.chain);
             assert_eq!(solution.swaps().len(), 2);
-            assert_eq!(solution.swaps()[0].token_in().address, eth());
-            assert_eq!(solution.swaps()[0].token_out().address, weth());
+            assert_eq!(solution.swaps()[0].token_in(), &eth());
+            assert_eq!(solution.swaps()[0].token_out(), &weth());
             assert_eq!(
                 solution.swaps()[0]
                     .component()
@@ -557,8 +555,8 @@ mod tests {
             let solution = encoder.add_weth_swaps(&solution, &encoder.chain);
             let last_swap = solution.swaps().last().unwrap();
             assert_eq!(solution.swaps().len(), 2);
-            assert_eq!(last_swap.token_in().address, eth());
-            assert_eq!(last_swap.token_out().address, weth());
+            assert_eq!(last_swap.token_in(), &eth());
+            assert_eq!(last_swap.token_out(), &weth());
             assert_eq!(last_swap.component().protocol_system, "weth");
         }
 
@@ -567,8 +565,8 @@ mod tests {
             // USDC -> ETH -> WETH (no swap needed to be added)
             let eth_weth_swap = Swap::new(
                 ProtocolComponent { protocol_system: "weth".to_string(), ..Default::default() },
-                default_token(eth()),
-                default_token(weth()),
+                eth(),
+                weth(),
             );
 
             let input_swaps = vec![swap_usdc_eth_univ4(), eth_weth_swap];
@@ -626,8 +624,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(dai().clone()),
-                    default_token(weth().clone()),
+                    dai().clone(),
+                    weth().clone(),
                 ),
                 Swap::new(
                     ProtocolComponent {
@@ -635,8 +633,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(dai().clone()),
-                    default_token(weth().clone()),
+                    dai().clone(),
+                    weth().clone(),
                 ),
                 Swap::new(
                     ProtocolComponent {
@@ -644,8 +642,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(weth().clone()),
-                    default_token(dai().clone()),
+                    weth().clone(),
+                    dai().clone(),
                 ),
             ];
 
@@ -677,8 +675,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(dai().clone()),
-                    default_token(weth().clone()),
+                    dai().clone(),
+                    weth().clone(),
                 ),
                 Swap::new(
                     ProtocolComponent {
@@ -686,8 +684,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(weth().clone()),
-                    default_token(usdc().clone()),
+                    weth().clone(),
+                    usdc().clone(),
                 ),
                 Swap::new(
                     ProtocolComponent {
@@ -695,8 +693,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(usdc().clone()),
-                    default_token(dai().clone()),
+                    usdc().clone(),
+                    dai().clone(),
                 ),
                 Swap::new(
                     ProtocolComponent {
@@ -704,8 +702,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(dai().clone()),
-                    default_token(wbtc().clone()),
+                    dai().clone(),
+                    wbtc().clone(),
                 ),
             ];
 
@@ -744,8 +742,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(weth()),
-                    default_token(dai()),
+                    weth(),
+                    dai(),
                 ),
                 Swap::new(
                     ProtocolComponent {
@@ -753,8 +751,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(dai()),
-                    default_token(weth()),
+                    dai(),
+                    weth(),
                 )
                 .with_split(0.5),
                 Swap::new(
@@ -763,8 +761,8 @@ mod tests {
                         protocol_system: "uniswap_v2".to_string(),
                         ..Default::default()
                     },
-                    default_token(dai()),
-                    default_token(weth()),
+                    dai(),
+                    weth(),
                 ),
             ];
 
@@ -808,8 +806,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(token_in.clone()),
-                default_token(token_out.clone()),
+                token_in.clone(),
+                token_out.clone(),
             );
 
             let solution = Solution::new(
@@ -860,8 +858,8 @@ mod tests {
                     protocol_system: "uniswap_v2".to_string(),
                     ..Default::default()
                 },
-                default_token(token_in.clone()),
-                default_token(token_out.clone()),
+                token_in.clone(),
+                token_out.clone(),
             );
 
             let solution = Solution::new(

--- a/src/encoding/models.rs
+++ b/src/encoding/models.rs
@@ -4,9 +4,7 @@ use clap::ValueEnum;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use tycho_common::{
-    models::{protocol::ProtocolComponent, token::Token},
-    simulation::protocol_sim::ProtocolSim,
-    Bytes,
+    models::protocol::ProtocolComponent, simulation::protocol_sim::ProtocolSim, Bytes,
 };
 
 use crate::encoding::serde_primitives::biguint_string;
@@ -157,9 +155,9 @@ pub struct Swap {
     /// Protocol component from tycho indexer
     component: ProtocolComponent,
     /// Token being input into the pool.
-    token_in: Token,
+    token_in: Bytes,
     /// Token being output from the pool.
-    token_out: Token,
+    token_out: Bytes,
     /// Decimal of the amount to be swapped in this operation (for example, 0.5 means 50%)
     #[serde(default)]
     split: f64,
@@ -176,8 +174,8 @@ pub struct Swap {
 impl Swap {
     pub fn new<T: Into<ProtocolComponent>>(
         component: T,
-        token_in: Token,
-        token_out: Token,
+        token_in: Bytes,
+        token_out: Bytes,
     ) -> Self {
         Self {
             component: component.into(),
@@ -218,11 +216,11 @@ impl Swap {
         &self.component
     }
 
-    pub fn token_in(&self) -> &Token {
+    pub fn token_in(&self) -> &Bytes {
         &self.token_in
     }
 
-    pub fn token_out(&self) -> &Token {
+    pub fn token_out(&self) -> &Bytes {
         &self.token_out
     }
 
@@ -246,8 +244,8 @@ impl Swap {
 impl PartialEq for Swap {
     fn eq(&self, other: &Self) -> bool {
         self.component() == other.component() &&
-            self.token_in().address == other.token_in().address &&
-            self.token_out().address == other.token_out().address &&
+            self.token_in() == other.token_in() &&
+            self.token_out() == other.token_out() &&
             self.split() == other.split() &&
             self.user_data() == other.user_data() &&
             self.estimated_amount_in() == other.estimated_amount_in()
@@ -409,13 +407,6 @@ pub struct EncodingContext {
     pub group_token_out: Bytes,
 }
 
-/// Creates a minimal `Token` from just an address, with zero-value defaults for other fields.
-/// Only available in tests and when the `test-utils` feature is enabled.
-#[cfg(any(test, feature = "test-utils"))]
-pub fn default_token(address: Bytes) -> Token {
-    Token::new(&address, "", 0, 0, &[], Default::default(), 100)
-}
-
 mod tests {
     use super::*;
 
@@ -448,16 +439,12 @@ mod tests {
             protocol_system: "uniswap_v2".to_string(),
         };
         let user_data = Bytes::from("0x1234");
-        let swap = Swap::new(
-            component,
-            default_token(Bytes::from("0x12")),
-            default_token(Bytes::from("0x34")),
-        )
-        .with_split(0.5)
-        .with_user_data(user_data.clone());
+        let swap = Swap::new(component, Bytes::from("0x12"), Bytes::from("0x34"))
+            .with_split(0.5)
+            .with_user_data(user_data.clone());
 
-        assert_eq!(swap.token_in().address, Bytes::from("0x12"));
-        assert_eq!(swap.token_out().address, Bytes::from("0x34"));
+        assert_eq!(*swap.token_in(), Bytes::from("0x12"));
+        assert_eq!(*swap.token_out(), Bytes::from("0x34"));
         assert_eq!(swap.component().protocol_system, "uniswap_v2");
         assert_eq!(swap.component().id, "i-am-an-id");
         assert_eq!(swap.split(), 0.5);

--- a/tests/optimized_transfers_integration_tests.rs
+++ b/tests/optimized_transfers_integration_tests.rs
@@ -5,7 +5,7 @@ use num_bigint::{BigInt, BigUint};
 use tycho_common::{models::protocol::ProtocolComponent, Bytes};
 use tycho_execution::encoding::{
     evm::utils::write_calldata_to_file,
-    models::{default_token, Solution, Swap, UserTransferType},
+    models::{Solution, Swap, UserTransferType},
 };
 
 use crate::common::{
@@ -44,8 +44,8 @@ fn test_uniswap_v3_uniswap_v2() {
             },
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
     let swap_wbtc_usdc = Swap::new(
         ProtocolComponent {
@@ -53,8 +53,8 @@ fn test_uniswap_v3_uniswap_v2() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdc.clone()),
+        wbtc.clone(),
+        usdc.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -119,8 +119,8 @@ fn test_uniswap_v3_uniswap_v3() {
             },
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
     let swap_wbtc_usdc = Swap::new(
         ProtocolComponent {
@@ -136,8 +136,8 @@ fn test_uniswap_v3_uniswap_v3() {
             },
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdc.clone()),
+        wbtc.clone(),
+        usdc.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -201,8 +201,8 @@ fn test_uniswap_v3_curve() {
             },
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
 
     let swap_wbtc_usdt = Swap::new(
@@ -228,8 +228,8 @@ fn test_uniswap_v3_curve() {
             },
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdt.clone()),
+        wbtc.clone(),
+        usdt.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -285,8 +285,8 @@ fn test_balancer_v2_uniswap_v2() {
             protocol_system: "vm:balancer_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
 
     let swap_wbtc_usdc = Swap::new(
@@ -295,8 +295,8 @@ fn test_balancer_v2_uniswap_v2() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdc.clone()),
+        wbtc.clone(),
+        usdc.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -355,8 +355,8 @@ fn test_multi_protocol() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(dai.clone()),
-        default_token(weth.clone()),
+        dai.clone(),
+        weth.clone(),
     );
 
     let balancer_swap_weth_wbtc = Swap::new(
@@ -365,8 +365,8 @@ fn test_multi_protocol() {
             protocol_system: "vm:balancer_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
 
     let curve_swap_wbtc_usdt = Swap::new(
@@ -392,8 +392,8 @@ fn test_multi_protocol() {
             },
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdt.clone()),
+        wbtc.clone(),
+        usdt.clone(),
     );
 
     // Ekubo
@@ -410,8 +410,7 @@ fn test_multi_protocol() {
         ]),
         ..Default::default()
     };
-    let ekubo_swap_usdt_usdc =
-        Swap::new(component, default_token(usdt.clone()), default_token(usdc.clone()));
+    let ekubo_swap_usdt_usdc = Swap::new(component, usdt.clone(), usdc.clone());
 
     // USV4
     // Fee and tick spacing information for this test is obtained by querying the
@@ -430,8 +429,8 @@ fn test_multi_protocol() {
             static_attributes: static_attributes_usdc_eth,
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(eth.clone()),
+        usdc.clone(),
+        eth.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -501,8 +500,8 @@ fn test_uniswap_v3_balancer_v3() {
             },
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
     let swap_wbtc_qnt = Swap::new(
         ProtocolComponent {
@@ -510,8 +509,8 @@ fn test_uniswap_v3_balancer_v3() {
             protocol_system: "vm:balancer_v3".to_string(),
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(qnt.clone()),
+        wbtc.clone(),
+        qnt.clone(),
     );
     let encoder = get_tycho_router_encoder();
 

--- a/tests/protocol_integration_tests.rs
+++ b/tests/protocol_integration_tests.rs
@@ -3,16 +3,13 @@ use std::{collections::HashMap, default::Default, str::FromStr, sync::Arc};
 
 use alloy::{hex, hex::encode};
 use num_bigint::{BigInt, BigUint};
-use tycho_common::{
-    models::{protocol::ProtocolComponent, token::Token, Chain},
-    Bytes,
-};
+use tycho_common::{models::protocol::ProtocolComponent, Bytes};
 use tycho_execution::encoding::{
     evm::{
         testing_utils::MockRFQState,
         utils::{biguint_to_u256, write_calldata_to_file},
     },
-    models::{default_token, Solution, Swap, UserTransferType},
+    models::{Solution, Swap, UserTransferType},
 };
 
 use crate::common::{
@@ -42,8 +39,7 @@ fn test_single_encoding_strategy_ekubo() {
         ..Default::default()
     };
 
-    let swap =
-        Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(component, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -99,8 +95,7 @@ fn test_single_encoding_strategy_ekubo_erc20() {
         ..Default::default()
     };
 
-    let swap =
-        Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(component, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -156,8 +151,7 @@ fn test_single_encoding_strategy_ekubo_mev_resist() {
         ..Default::default()
     };
 
-    let swap =
-        Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(component, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -202,8 +196,7 @@ fn test_single_encoding_strategy_maverick() {
     };
     let token_in = Bytes::from("0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f");
     let token_out = usdc();
-    let swap =
-        Swap::new(maverick_pool, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(maverick_pool, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -262,8 +255,8 @@ fn test_single_encoding_strategy_usv4_eth_in() {
             static_attributes: static_attributes_eth_pepe,
             ..Default::default()
         },
-        default_token(eth.clone()),
-        default_token(pepe.clone()),
+        eth.clone(),
+        pepe.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -326,8 +319,8 @@ fn test_single_encoding_strategy_usv4_eth_out() {
             static_attributes: static_attributes_usdc_eth,
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(eth.clone()),
+        usdc.clone(),
+        eth.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -399,8 +392,8 @@ fn test_single_encoding_strategy_usv4_grouped_swap() {
             static_attributes: static_attributes_usdc_eth,
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(eth.clone()),
+        usdc.clone(),
+        eth.clone(),
     );
 
     let swap_eth_pepe = Swap::new(
@@ -410,8 +403,8 @@ fn test_single_encoding_strategy_usv4_grouped_swap() {
             static_attributes: static_attributes_eth_pepe,
             ..Default::default()
         },
-        default_token(eth.clone()),
-        default_token(pepe.clone()),
+        eth.clone(),
+        pepe.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -528,8 +521,8 @@ fn test_single_encoding_strategy_usv4_and_hooks_grouped_swap() {
             static_attributes: static_attributes_weth_usdt,
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(usdc.clone()),
+        weth.clone(),
+        usdc.clone(),
     );
 
     let swap_usdc_eth = Swap::new(
@@ -539,8 +532,8 @@ fn test_single_encoding_strategy_usv4_and_hooks_grouped_swap() {
             static_attributes: static_attributes_usdc_eth,
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(eth.clone()),
+        usdc.clone(),
+        eth.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -606,8 +599,8 @@ fn test_single_encoding_strategy_ekubo_grouped_swap() {
             ]),
             ..Default::default()
         },
-        default_token(usde.clone()),
-        default_token(usdc.clone()),
+        usde.clone(),
+        usdc.clone(),
     );
 
     // Second swap: USDC -> USDT
@@ -625,8 +618,8 @@ fn test_single_encoding_strategy_ekubo_grouped_swap() {
             ]),
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(usdt.clone()),
+        usdc.clone(),
+        usdt.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -687,8 +680,7 @@ fn test_single_encoding_strategy_curve() {
         ..Default::default()
     };
 
-    let swap =
-        Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(component, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -748,8 +740,7 @@ fn test_single_encoding_strategy_curve_st_eth() {
         ..Default::default()
     };
 
-    let swap =
-        Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(component, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -818,7 +809,7 @@ fn test_single_encoding_strategy_curve_protocol_will_debit_from_vault() {
         ..Default::default()
     };
 
-    let swap = Swap::new(curve_tripool, default_token(dai.clone()), default_token(usdc.clone()));
+    let swap = Swap::new(curve_tripool, dai.clone(), usdc.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -868,8 +859,7 @@ fn test_single_encoding_strategy_balancer_v3() {
     };
     let token_in = Bytes::from("0x097ffedb80d4b2ca6105a07a4d90eb739c45a666");
     let token_out = Bytes::from("0x30881baa943777f92dc934d53d3bfdf33382cab3");
-    let swap =
-        Swap::new(balancer_pool, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(balancer_pool, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -940,13 +930,9 @@ fn test_single_encoding_strategy_bebop() {
         ..Default::default()
     };
 
-    let swap = Swap::new(
-        bebop_component,
-        default_token(token_in.clone()),
-        default_token(token_out.clone()),
-    )
-    .with_estimated_amount_in(BigUint::from_str("200000000").unwrap())
-    .with_protocol_state(Arc::new(bebop_state));
+    let swap = Swap::new(bebop_component, token_in.clone(), token_out.clone())
+        .with_estimated_amount_in(BigUint::from_str("200000000").unwrap())
+        .with_protocol_state(Arc::new(bebop_state));
 
     let encoder = get_tycho_router_encoder();
 
@@ -1017,13 +1003,9 @@ fn test_single_encoding_strategy_bebop_aggregate() {
         ..Default::default()
     };
 
-    let swap = Swap::new(
-        bebop_component,
-        default_token(token_in.clone()),
-        default_token(token_out.clone()),
-    )
-    .with_estimated_amount_in(BigUint::from_str("20000000000").unwrap())
-    .with_protocol_state(Arc::new(bebop_state));
+    let swap = Swap::new(bebop_component, token_in.clone(), token_out.clone())
+        .with_estimated_amount_in(BigUint::from_str("20000000000").unwrap())
+        .with_protocol_state(Arc::new(bebop_state));
 
     let encoder = get_tycho_router_encoder();
 
@@ -1117,10 +1099,9 @@ fn test_single_encoding_strategy_hashflow() {
         ..Default::default()
     };
 
-    let swap_usdc_wbtc =
-        Swap::new(hashflow_component, default_token(usdc.clone()), default_token(wbtc.clone()))
-            .with_estimated_amount_in(BigUint::from_str("4308094737").unwrap())
-            .with_protocol_state(Arc::new(hashflow_state));
+    let swap_usdc_wbtc = Swap::new(hashflow_component, usdc.clone(), wbtc.clone())
+        .with_estimated_amount_in(BigUint::from_str("4308094737").unwrap())
+        .with_protocol_state(Arc::new(hashflow_state));
     let encoder = get_tycho_router_encoder();
 
     let solution = Solution::new(
@@ -1165,8 +1146,7 @@ fn test_single_encoding_strategy_fluid() {
     let token_in = Bytes::from("0x9d39a5de30e57443bff2a8307a4256c8797a3497");
     let token_out = Bytes::from("0xdac17f958d2ee523a2206206994597c13d831ec7");
     let alice = Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap();
-    let swap =
-        Swap::new(fluid_dex, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(fluid_dex, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1217,10 +1197,8 @@ fn test_sequential_encoding_strategy_fluid() {
     let usdt = Bytes::from("0xdac17f958d2ee523a2206206994597c13d831ec7");
     let token_out = Bytes::from("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
     let alice = Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap();
-    let swap_1 =
-        Swap::new(fluid_dex_1, default_token(token_in.clone()), default_token(usdt.clone()));
-    let swap_2 =
-        Swap::new(fluid_dex_2, default_token(usdt.clone()), default_token(token_out.clone()));
+    let swap_1 = Swap::new(fluid_dex_1, token_in.clone(), usdt.clone());
+    let swap_2 = Swap::new(fluid_dex_2, usdt.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1267,11 +1245,7 @@ fn test_single_encoding_strategy_rocketpool_deposit() {
     };
     let token_in = eth();
     let token_out = Bytes::from("0xae78736Cd615f374D3085123A210448E74Fc6393");
-    let swap = Swap::new(
-        rocketpool_pool,
-        default_token(token_in.clone()),
-        default_token(token_out.clone()),
-    );
+    let swap = Swap::new(rocketpool_pool, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1322,11 +1296,7 @@ fn test_single_encoding_strategy_rocketpool_burn() {
     };
     let token_in = Bytes::from("0xae78736Cd615f374D3085123A210448E74Fc6393");
     let token_out = eth();
-    let swap = Swap::new(
-        rocketpool_pool,
-        default_token(token_in.clone()),
-        default_token(token_out.clone()),
-    );
+    let swap = Swap::new(rocketpool_pool, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1377,11 +1347,7 @@ fn test_single_encoding_strategy_slipstreams() {
     };
     let token_in = Bytes::from("0x4200000000000000000000000000000000000006");
     let token_out = Bytes::from("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
-    let swap = Swap::new(
-        slipstreams_pool,
-        default_token(token_in.clone()),
-        default_token(token_out.clone()),
-    );
+    let swap = Swap::new(slipstreams_pool, token_in.clone(), token_out.clone());
 
     let encoder = get_base_tycho_router_encoder();
 
@@ -1430,11 +1396,7 @@ fn test_sequential_encoding_strategy_slipstreams() {
     };
     let weth = Bytes::from("0x4200000000000000000000000000000000000006");
     let usdc = Bytes::from("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
-    let swap1 = Swap::new(
-        slipstreams_weth_usdc_pool,
-        default_token(weth.clone()),
-        default_token(usdc.clone()),
-    );
+    let swap1 = Swap::new(slipstreams_weth_usdc_pool, weth.clone(), usdc.clone());
     let slipstreams_cbbtc_usdc_pool = ProtocolComponent {
         id: String::from("0x4e962BB3889Bf030368F56810A9c96B83CB3E778"),
         protocol_system: String::from("aerodrome_slipstreams"),
@@ -1445,11 +1407,7 @@ fn test_sequential_encoding_strategy_slipstreams() {
         ..Default::default()
     };
     let btc = Bytes::from("0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf");
-    let swap2 = Swap::new(
-        slipstreams_cbbtc_usdc_pool,
-        default_token(usdc.clone()),
-        default_token(btc.clone()),
-    );
+    let swap2 = Swap::new(slipstreams_cbbtc_usdc_pool, usdc.clone(), btc.clone());
 
     let encoder = get_base_tycho_router_encoder();
 
@@ -1494,8 +1452,7 @@ fn test_single_encoding_strategy_erc4626() {
     };
     let token_in = Bytes::from("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
     let token_out = Bytes::from("0xfE6eb3b609a7C8352A241f7F3A21CEA4e9209B8f");
-    let swap =
-        Swap::new(erc4626_pool, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(erc4626_pool, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1540,14 +1497,14 @@ fn test_sequential_encoding_strategy_erc4626() {
     };
     let sp_usdc = Bytes::from("0x28b3a8fb53b741a8fd78c0fb9a6b2393d896a43d");
     let usdc = Bytes::from("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
-    let swap1 = Swap::new(spusdc_pool, default_token(sp_usdc.clone()), default_token(usdc.clone()));
+    let swap1 = Swap::new(spusdc_pool, sp_usdc.clone(), usdc.clone());
     let susdc_pool = ProtocolComponent {
         id: String::from("0xbc65ad17c5c0a2a4d159fa5a503f4992c7b545fe"),
         protocol_system: String::from("erc4626"),
         ..Default::default()
     };
     let susdc = Bytes::from("0xbc65ad17c5c0a2a4d159fa5a503f4992c7b545fe");
-    let swap2 = Swap::new(susdc_pool, default_token(usdc.clone()), default_token(susdc.clone()));
+    let swap2 = Swap::new(susdc_pool, usdc.clone(), susdc.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1605,8 +1562,8 @@ fn test_single_swap_with_univ4_angstrom() {
             static_attributes: usdc_weth_attributes,
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(weth.clone()),
+        usdc.clone(),
+        weth.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -1652,8 +1609,7 @@ fn test_single_encoding_strategy_weth_wrap() {
         ProtocolComponent { protocol_system: String::from("weth"), ..Default::default() };
     let token_in = eth();
     let token_out = weth();
-    let swap =
-        Swap::new(weth_executor, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(weth_executor, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1694,8 +1650,7 @@ fn test_single_encoding_strategy_weth_unwrap() {
         ProtocolComponent { protocol_system: String::from("weth"), ..Default::default() };
     let token_in = weth();
     let token_out = eth();
-    let swap =
-        Swap::new(weth_executor, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(weth_executor, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1742,8 +1697,8 @@ fn test_sequential_encoding_strategy_weth_wrap_added() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth().clone()),
-        default_token(dai().clone()),
+        weth(),
+        dai(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -1802,8 +1757,7 @@ fn test_single_encoding_strategy_ekubo_v3() {
         ..Default::default()
     };
 
-    let swap =
-        Swap::new(component, default_token(token_in.clone()), default_token(token_out.clone()));
+    let swap = Swap::new(component, token_in.clone(), token_out.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1859,8 +1813,8 @@ fn test_single_ekubo_v3_grouped_swap() {
             ]),
             ..Default::default()
         },
-        default_token(usdt()),
-        default_token(usdc()),
+        usdt(),
+        usdc(),
     );
 
     // Second swap: USDC -> ETH
@@ -1878,8 +1832,8 @@ fn test_single_ekubo_v3_grouped_swap() {
             ]),
             ..Default::default()
         },
-        default_token(usdc()),
-        default_token(eth()),
+        usdc(),
+        eth(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -1926,13 +1880,13 @@ fn test_sequential_encoding_strategy_etherfi_unwrap_weeth() {
     };
     let weeth = Bytes::from("0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee");
     let eeth = Bytes::from("0x35fA164735182de50811E8e2E824cFb9B6118ac2");
-    let swap1 = Swap::new(weeth_pool, default_token(weeth.clone()), default_token(eeth.clone()));
+    let swap1 = Swap::new(weeth_pool, weeth.clone(), eeth.clone());
     let eeth_pool = ProtocolComponent {
         id: String::from("0x35fA164735182de50811E8e2E824cFb9B6118ac2"),
         protocol_system: String::from("etherfi"),
         ..Default::default()
     };
-    let swap2 = Swap::new(eeth_pool, default_token(eeth.clone()), default_token(eth()));
+    let swap2 = Swap::new(eeth_pool, eeth.clone(), eth());
 
     let encoder = get_tycho_router_encoder();
 
@@ -1982,7 +1936,7 @@ fn test_sequential_encoding_strategy_etherfi_wrap_eeth() {
         protocol_system: String::from("etherfi"),
         ..Default::default()
     };
-    let swap1 = Swap::new(eeth_pool, default_token(eth()), default_token(eeth.clone()));
+    let swap1 = Swap::new(eeth_pool, eth(), eeth.clone());
 
     let weeth_pool = ProtocolComponent {
         id: String::from("0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee"),
@@ -1990,7 +1944,7 @@ fn test_sequential_encoding_strategy_etherfi_wrap_eeth() {
         ..Default::default()
     };
     let weeth = Bytes::from("0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee");
-    let swap2 = Swap::new(weeth_pool, default_token(eeth.clone()), default_token(weeth.clone()));
+    let swap2 = Swap::new(weeth_pool, eeth.clone(), weeth.clone());
 
     let encoder = get_tycho_router_encoder();
 
@@ -2046,9 +2000,6 @@ fn test_single_encoding_strategy_usv4_twif_fee_token() {
     static_attributes.insert("key_lp_fee".into(), pool_fee);
     static_attributes.insert("tick_spacing".into(), tick_spacing);
 
-    let twif_token = Token::new(&twif, "TWIF", 18, 600, &[], Chain::Ethereum, 50);
-    let usdc_token = Token::new(&usdc, "USDC", 6, 0, &[], Chain::Ethereum, 100);
-
     let swap = Swap::new(
         ProtocolComponent {
             id: "0x66315f75b2071302fa143f44ae0ec79c0c98f837693fa7150f8ac7ed1fa7576e".to_string(),
@@ -2056,8 +2007,8 @@ fn test_single_encoding_strategy_usv4_twif_fee_token() {
             static_attributes,
             ..Default::default()
         },
-        twif_token,
-        usdc_token,
+        twif.clone(),
+        usdc.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -2123,9 +2074,6 @@ fn test_single_encoding_strategy_usv4_twif_fee_token_output() {
     static_attributes.insert("key_lp_fee".into(), pool_fee);
     static_attributes.insert("tick_spacing".into(), tick_spacing);
 
-    let usdc_token = Token::new(&usdc, "USDC", 6, 0, &[], Chain::Ethereum, 100);
-    let twif_token = Token::new(&twif, "TWIF", 18, 600, &[], Chain::Ethereum, 50);
-
     let swap = Swap::new(
         ProtocolComponent {
             id: "0x66315f75b2071302fa143f44ae0ec79c0c98f837693fa7150f8ac7ed1fa7576e".to_string(),
@@ -2133,8 +2081,8 @@ fn test_single_encoding_strategy_usv4_twif_fee_token_output() {
             static_attributes,
             ..Default::default()
         },
-        usdc_token,
-        twif_token,
+        usdc.clone(),
+        twif.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -2204,9 +2152,6 @@ fn test_single_encoding_strategy_usv4_grouped_twif_intermediary() {
     static_attributes_2.insert("key_lp_fee".into(), pool_fee);
     static_attributes_2.insert("tick_spacing".into(), tick_spacing);
 
-    let usdc_token = Token::new(&usdc, "USDC", 6, 0, &[], Chain::Ethereum, 100);
-    let twif_token = Token::new(&twif, "TWIF", 18, 600, &[], Chain::Ethereum, 50);
-
     let pool_id = "0x66315f75b2071302fa143f44ae0ec79c0c98f837693fa7150f8ac7ed1fa7576e";
 
     // First swap: USDC -> TWIF
@@ -2217,8 +2162,8 @@ fn test_single_encoding_strategy_usv4_grouped_twif_intermediary() {
             static_attributes: static_attributes_1,
             ..Default::default()
         },
-        usdc_token.clone(),
-        twif_token.clone(),
+        usdc.clone(),
+        twif.clone(),
     );
 
     // Second swap: TWIF -> USDC (same pool, reversed)
@@ -2229,8 +2174,8 @@ fn test_single_encoding_strategy_usv4_grouped_twif_intermediary() {
             static_attributes: static_attributes_2,
             ..Default::default()
         },
-        twif_token,
-        usdc_token,
+        twif.clone(),
+        usdc.clone(),
     );
 
     let encoder = get_tycho_router_encoder();

--- a/tests/sequential_strategy_integration_tests.rs
+++ b/tests/sequential_strategy_integration_tests.rs
@@ -6,7 +6,7 @@ use num_bigint::{BigInt, BigUint};
 use tycho_common::{models::protocol::ProtocolComponent, Bytes};
 use tycho_execution::encoding::{
     evm::utils::write_calldata_to_file,
-    models::{default_token, Solution, Swap, UserTransferType},
+    models::{Solution, Swap, UserTransferType},
 };
 
 use crate::common::{
@@ -33,8 +33,8 @@ fn test_sequential_swap_strategy_encoder() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
     let swap_wbtc_usdc = Swap::new(
         ProtocolComponent {
@@ -42,8 +42,8 @@ fn test_sequential_swap_strategy_encoder() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdc.clone()),
+        wbtc.clone(),
+        usdc.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -96,8 +96,8 @@ fn test_sequential_swap_strategy_encoder_transfer_from_integration() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
     let swap_wbtc_usdc = Swap::new(
         ProtocolComponent {
@@ -105,8 +105,8 @@ fn test_sequential_swap_strategy_encoder_transfer_from_integration() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdc.clone()),
+        wbtc.clone(),
+        usdc.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -211,8 +211,8 @@ fn test_sequential_strategy_cyclic_swap() {
             },
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(weth.clone()),
+        usdc.clone(),
+        weth.clone(),
     );
 
     // WETH -> USDC (Pool 2)
@@ -231,8 +231,8 @@ fn test_sequential_strategy_cyclic_swap() {
             },
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(usdc.clone()),
+        weth.clone(),
+        usdc.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -334,8 +334,8 @@ fn test_sequential_strategy_cyclic_swap_and_vault() {
             },
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(weth.clone()),
+        usdc.clone(),
+        weth.clone(),
     );
 
     // WETH -> USDC (Pool 2)
@@ -354,8 +354,8 @@ fn test_sequential_strategy_cyclic_swap_and_vault() {
             },
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(usdc.clone()),
+        weth.clone(),
+        usdc.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -447,8 +447,8 @@ fn test_sequential_swap_strategy_encoder_with_fees() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
     let swap_wbtc_usdc = Swap::new(
         ProtocolComponent {
@@ -456,8 +456,8 @@ fn test_sequential_swap_strategy_encoder_with_fees() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdc.clone()),
+        wbtc.clone(),
+        usdc.clone(),
     );
     let encoder = get_tycho_router_encoder();
 

--- a/tests/single_strategy_integration_tests.rs
+++ b/tests/single_strategy_integration_tests.rs
@@ -7,7 +7,7 @@ use num_bigint::BigUint;
 use tycho_common::{models::protocol::ProtocolComponent, Bytes};
 use tycho_execution::encoding::{
     evm::utils::{biguint_to_u256, write_calldata_to_file},
-    models::{default_token, Solution, Swap, UserTransferType},
+    models::{Solution, Swap, UserTransferType},
 };
 
 use crate::common::{
@@ -29,8 +29,8 @@ fn test_single_swap_strategy_encoder() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(dai.clone()),
+        weth.clone(),
+        dai.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -111,8 +111,8 @@ fn test_single_swap_strategy_encoder_transfer_from() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(dai.clone()),
+        weth.clone(),
+        dai.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -194,8 +194,8 @@ fn test_single_swap_with_client_fees() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(dai.clone()),
+        weth.clone(),
+        dai.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -249,8 +249,8 @@ fn test_single_swap_with_fees_and_client_contribution() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(dai.clone()),
+        weth.clone(),
+        dai.clone(),
     );
     let encoder = get_tycho_router_encoder();
 

--- a/tests/split_strategy_integration_tests.rs
+++ b/tests/split_strategy_integration_tests.rs
@@ -7,7 +7,7 @@ use num_bigint::{BigInt, BigUint};
 use tycho_common::{models::protocol::ProtocolComponent, Bytes};
 use tycho_execution::encoding::{
     evm::utils::write_calldata_to_file,
-    models::{default_token, Solution, Swap, UserTransferType},
+    models::{Solution, Swap, UserTransferType},
 };
 
 use crate::common::{
@@ -38,8 +38,8 @@ fn test_split_swap_strategy_encoder() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(dai.clone()),
+        weth.clone(),
+        dai.clone(),
     )
     .with_split(0.5f64);
     let swap_weth_wbtc = Swap::new(
@@ -48,8 +48,8 @@ fn test_split_swap_strategy_encoder() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
     let swap_dai_usdc = Swap::new(
         ProtocolComponent {
@@ -57,8 +57,8 @@ fn test_split_swap_strategy_encoder() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(dai.clone()),
-        default_token(usdc.clone()),
+        dai.clone(),
+        usdc.clone(),
     );
     let swap_wbtc_usdc = Swap::new(
         ProtocolComponent {
@@ -66,8 +66,8 @@ fn test_split_swap_strategy_encoder() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdc.clone()),
+        wbtc.clone(),
+        usdc.clone(),
     );
     let encoder = get_tycho_router_encoder();
 
@@ -131,8 +131,8 @@ fn test_split_input_cyclic_swap() {
             },
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(weth.clone()),
+        usdc.clone(),
+        weth.clone(),
     )
     .with_split(0.6f64) // 60% of input
     ;
@@ -153,8 +153,8 @@ fn test_split_input_cyclic_swap() {
             },
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(weth.clone()),
+        usdc.clone(),
+        weth.clone(),
     );
 
     // WETH -> USDC (Pool 2)
@@ -173,8 +173,8 @@ fn test_split_input_cyclic_swap() {
             },
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(usdc.clone()),
+        weth.clone(),
+        usdc.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -291,8 +291,8 @@ fn test_split_output_cyclic_swap() {
             },
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(weth.clone()),
+        usdc.clone(),
+        weth.clone(),
     );
 
     let swap_weth_usdc_v3_pool1 = Swap::new(
@@ -308,8 +308,8 @@ fn test_split_output_cyclic_swap() {
             },
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(usdc.clone()),
+        weth.clone(),
+        usdc.clone(),
     )
     .with_split(0.6f64);
 
@@ -328,8 +328,8 @@ fn test_split_output_cyclic_swap() {
             },
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(usdc.clone()),
+        weth.clone(),
+        usdc.clone(),
     );
 
     let encoder = get_tycho_router_encoder();
@@ -443,8 +443,8 @@ fn test_split_swap_strategy_with_fees() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(dai.clone()),
+        weth.clone(),
+        dai.clone(),
     )
     .with_split(0.5f64);
     let swap_weth_wbtc = Swap::new(
@@ -453,8 +453,8 @@ fn test_split_swap_strategy_with_fees() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(weth.clone()),
-        default_token(wbtc.clone()),
+        weth.clone(),
+        wbtc.clone(),
     );
     let swap_dai_usdc = Swap::new(
         ProtocolComponent {
@@ -462,8 +462,8 @@ fn test_split_swap_strategy_with_fees() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(dai.clone()),
-        default_token(usdc.clone()),
+        dai.clone(),
+        usdc.clone(),
     );
     let swap_wbtc_usdc = Swap::new(
         ProtocolComponent {
@@ -471,8 +471,8 @@ fn test_split_swap_strategy_with_fees() {
             protocol_system: "uniswap_v2".to_string(),
             ..Default::default()
         },
-        default_token(wbtc.clone()),
-        default_token(usdc.clone()),
+        wbtc.clone(),
+        usdc.clone(),
     );
     let encoder = get_tycho_router_encoder();
 

--- a/tests/uniswap_x_integration_tests.rs
+++ b/tests/uniswap_x_integration_tests.rs
@@ -8,7 +8,7 @@ use tycho_execution::encoding::{
         approvals::protocol_approvals_manager::ProtocolApprovalsManager,
         utils::{bytes_to_address, write_calldata_to_file},
     },
-    models::{default_token, Solution, Swap},
+    models::{Solution, Swap},
 };
 
 use crate::common::{
@@ -47,8 +47,8 @@ fn test_sequential_swap_usx() {
             },
             ..Default::default()
         },
-        default_token(dai.clone()),
-        default_token(usdc.clone()),
+        dai.clone(),
+        usdc.clone(),
     );
     let swap_usdc_usdt = Swap::new(
         ProtocolComponent {
@@ -62,8 +62,8 @@ fn test_sequential_swap_usx() {
             },
             ..Default::default()
         },
-        default_token(usdc.clone()),
-        default_token(usdt.clone()),
+        usdc.clone(),
+        usdt.clone(),
     );
     let encoder = get_tycho_router_encoder();
 


### PR DESCRIPTION
Only the token address was ever used from the Token struct, so simplify Swap to take Bytes directly. Removes the default_token test helper.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
