### PR TITLE
chore: extend BUSL change date to 4 years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -27,7 +27,7 @@ Additional Use Grant: You may use the Licensed Work in production to:
                       operate your own instance of the Licensed Work or any
                       derivative thereof.
 
-Change Date:          2028-03-19
+Change Date:          2030-03-19
 
 Change License:       MIT License
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ This repository is licensed under the [Business Source License 1.1](LICENSE) (BU
 **What you cannot do:**
 - Deploy, redeploy, or operate your own instance of the Tycho Router or any derivative
 
-On **2028-03-19**, the license converts to MIT, granting full open-source rights.
+On **2030-03-19**, the license converts to MIT, granting full open-source rights.
 
 For commercial licensing inquiries, contact [legal@propellerheads.xyz](mailto:legal@propellerheads.xyz).


### PR DESCRIPTION
## Summary

- Updates the BUSL-1.1 Change Date from 2028-03-19 (2 years) to 2030-03-19 (4 years)
- Updates both LICENSE and README.md