### PR TITLE
fix: replace block_in_place with runtime-safe blocking pattern

### DIFF
--- a/src/encoding/evm/approvals/permit2.rs
+++ b/src/encoding/evm/approvals/permit2.rs
@@ -101,7 +101,7 @@ impl TryFrom<&models::PermitSingle> for PermitSingle {
 impl Permit2 {
     pub fn new() -> Result<Self, EncodingError> {
         let (handle, runtime) = create_encoding_runtime()?;
-        let client = on_blocking_thread(|| handle.block_on(get_client()))?;
+        let client = on_blocking_thread(|| handle.block_on(get_client()))??;
         Ok(Self {
             address: Address::from_str("0x000000000022D473030F116dDEE9F6B43aC78BA3")
                 .map_err(|_| EncodingError::FatalError("Permit2 address not valid".to_string()))?,
@@ -129,7 +129,7 @@ impl Permit2 {
         let output = on_blocking_thread(|| {
             self.runtime_handle
                 .block_on(async { self.client.call(tx).await })
-        });
+        })?;
         match output {
             Ok(response) => {
                 let allowance: Allowance = Allowance::abi_decode(&response).map_err(|_| {
@@ -347,7 +347,8 @@ mod tests {
                 // Wait for the transaction to be mined
                 pending_tx.get_receipt().await.unwrap()
             })
-        });
+        })
+        .unwrap();
         assert!(receipt.status(), "Approve transaction failed");
 
         let spender = Bytes::from_str("0xba12222222228d8ba445958a75a0704d566bf2c8").unwrap();

--- a/src/encoding/evm/approvals/permit2.rs
+++ b/src/encoding/evm/approvals/permit2.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use alloy::{
     core::sol,
@@ -9,17 +9,17 @@ use alloy::{
 };
 use chrono::Utc;
 use num_bigint::BigUint;
-use tokio::{
-    runtime::{Handle, Runtime},
-    task::block_in_place,
-};
+use tokio::runtime::Handle;
 use tycho_common::Bytes;
 
 use crate::encoding::{
     errors::EncodingError,
     evm::{
         encoding_utils::encode_input,
-        utils::{biguint_to_u256, bytes_to_address, get_client, get_runtime, EVMProvider},
+        utils::{
+            biguint_to_u256, bytes_to_address, create_encoding_runtime, get_client,
+            on_blocking_thread, EVMProvider, SafeRuntime,
+        },
     },
     models,
 };
@@ -32,7 +32,7 @@ pub struct Permit2 {
     client: EVMProvider,
     runtime_handle: Handle,
     #[allow(dead_code)]
-    runtime: Option<Arc<Runtime>>,
+    runtime: SafeRuntime,
 }
 
 /// Type alias for representing allowance data as a tuple of (amount, expiration, nonce). Used for
@@ -100,8 +100,8 @@ impl TryFrom<&models::PermitSingle> for PermitSingle {
 
 impl Permit2 {
     pub fn new() -> Result<Self, EncodingError> {
-        let (handle, runtime) = get_runtime()?;
-        let client = block_in_place(|| handle.block_on(get_client()))?;
+        let (handle, runtime) = create_encoding_runtime()?;
+        let client = on_blocking_thread(|| handle.block_on(get_client()))?;
         Ok(Self {
             address: Address::from_str("0x000000000022D473030F116dDEE9F6B43aC78BA3")
                 .map_err(|_| EncodingError::FatalError("Permit2 address not valid".to_string()))?,
@@ -126,7 +126,7 @@ impl Permit2 {
             ..Default::default()
         };
 
-        let output = block_in_place(|| {
+        let output = on_blocking_thread(|| {
             self.runtime_handle
                 .block_on(async { self.client.call(tx).await })
         });
@@ -337,7 +337,7 @@ mod tests {
             input: TransactionInput { input: Some(AlloyBytes::from(data)), data: None },
             ..Default::default()
         };
-        let receipt = block_in_place(|| {
+        let receipt = on_blocking_thread(|| {
             permit2.runtime_handle.block_on(async {
                 let pending_tx = permit2
                     .client

--- a/src/encoding/evm/approvals/protocol_approvals_manager.rs
+++ b/src/encoding/evm/approvals/protocol_approvals_manager.rs
@@ -26,7 +26,7 @@ pub struct ProtocolApprovalsManager {
 impl ProtocolApprovalsManager {
     pub fn new() -> Result<Self, EncodingError> {
         let (handle, runtime) = create_encoding_runtime()?;
-        let client = on_blocking_thread(|| handle.block_on(get_client()))?;
+        let client = on_blocking_thread(|| handle.block_on(get_client()))??;
         Ok(Self { client, runtime_handle: handle, runtime })
     }
 
@@ -49,7 +49,7 @@ impl ProtocolApprovalsManager {
         let output = on_blocking_thread(|| {
             self.runtime_handle
                 .block_on(async { self.client.call(tx).await })
-        });
+        })?;
         match output {
             Ok(response) => {
                 let allowance: U256 = U256::abi_decode(&response).map_err(|_| {

--- a/src/encoding/evm/approvals/protocol_approvals_manager.rs
+++ b/src/encoding/evm/approvals/protocol_approvals_manager.rs
@@ -1,21 +1,18 @@
-use std::sync::Arc;
-
 use alloy::{
     primitives::{Address, Bytes, TxKind, U256},
     providers::Provider,
     rpc::types::{TransactionInput, TransactionRequest},
     sol_types::SolValue,
 };
-use tokio::{
-    runtime::{Handle, Runtime},
-    task::block_in_place,
-};
+use tokio::runtime::Handle;
 
 use crate::encoding::{
     errors::EncodingError,
     evm::{
         encoding_utils::encode_input,
-        utils::{get_client, get_runtime, EVMProvider},
+        utils::{
+            create_encoding_runtime, get_client, on_blocking_thread, EVMProvider, SafeRuntime,
+        },
     },
 };
 
@@ -24,12 +21,12 @@ pub struct ProtocolApprovalsManager {
     client: EVMProvider,
     runtime_handle: Handle,
     #[allow(dead_code)]
-    runtime: Option<Arc<Runtime>>,
+    runtime: SafeRuntime,
 }
 impl ProtocolApprovalsManager {
     pub fn new() -> Result<Self, EncodingError> {
-        let (handle, runtime) = get_runtime()?;
-        let client = block_in_place(|| handle.block_on(get_client()))?;
+        let (handle, runtime) = create_encoding_runtime()?;
+        let client = on_blocking_thread(|| handle.block_on(get_client()))?;
         Ok(Self { client, runtime_handle: handle, runtime })
     }
 
@@ -49,7 +46,7 @@ impl ProtocolApprovalsManager {
             ..Default::default()
         };
 
-        let output = block_in_place(|| {
+        let output = on_blocking_thread(|| {
             self.runtime_handle
                 .block_on(async { self.client.call(tx).await })
         });

--- a/src/encoding/evm/swap_encoder/bebop.rs
+++ b/src/encoding/evm/swap_encoder/bebop.rs
@@ -89,7 +89,7 @@ impl SwapEncoder for BebopSwapEncoder {
                         .request_signed_quote(params)
                         .await
                 })
-            })?;
+            })??;
             let bebop_calldata = signed_quote
                 .quote_attributes
                 .get("calldata")

--- a/src/encoding/evm/swap_encoder/bebop.rs
+++ b/src/encoding/evm/swap_encoder/bebop.rs
@@ -1,10 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use alloy::sol_types::SolValue;
-use tokio::{
-    runtime::{Handle, Runtime},
-    task::block_in_place,
-};
+use tokio::runtime::Handle;
 use tycho_common::{
     models::{protocol::GetAmountOutParams, Chain},
     Bytes,
@@ -12,7 +9,9 @@ use tycho_common::{
 
 use crate::encoding::{
     errors::EncodingError,
-    evm::utils::{biguint_to_u256, bytes_to_address, get_runtime},
+    evm::utils::{
+        biguint_to_u256, bytes_to_address, create_encoding_runtime, on_blocking_thread, SafeRuntime,
+    },
     models::{EncodingContext, Swap},
     swap_encoder::SwapEncoder,
 };
@@ -29,7 +28,7 @@ pub struct BebopSwapEncoder {
     executor_address: Bytes,
     runtime_handle: Handle,
     #[allow(dead_code)]
-    runtime: Option<Arc<Runtime>>,
+    runtime: SafeRuntime,
 }
 
 impl SwapEncoder for BebopSwapEncoder {
@@ -38,7 +37,7 @@ impl SwapEncoder for BebopSwapEncoder {
         _chain: Chain,
         _config: Option<HashMap<String, String>>,
     ) -> Result<Self, EncodingError> {
-        let (runtime_handle, runtime) = get_runtime()?;
+        let (runtime_handle, runtime) = create_encoding_runtime()?;
         Ok(Self { executor_address, runtime_handle, runtime })
     }
 
@@ -84,7 +83,7 @@ impl SwapEncoder for BebopSwapEncoder {
                 sender: router_address.clone(),
                 receiver: router_address,
             };
-            let signed_quote = block_in_place(|| {
+            let signed_quote = on_blocking_thread(|| {
                 self.runtime_handle.block_on(async {
                     indicatively_priced_state
                         .request_signed_quote(params)
@@ -137,7 +136,7 @@ impl SwapEncoder for BebopSwapEncoder {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{str::FromStr, sync::Arc};
 
     use alloy::hex::encode;
     use num_bigint::BigUint;

--- a/src/encoding/evm/swap_encoder/hashflow.rs
+++ b/src/encoding/evm/swap_encoder/hashflow.rs
@@ -70,7 +70,7 @@ impl SwapEncoder for HashflowSwapEncoder {
                     })
                     .await
             })
-        })?;
+        })??;
 
         // Encode packed data for the executor
         // Format: approval_needed | hashflow_calldata[..]

--- a/src/encoding/evm/swap_encoder/hashflow.rs
+++ b/src/encoding/evm/swap_encoder/hashflow.rs
@@ -1,10 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use alloy::sol_types::SolValue;
-use tokio::{
-    runtime::{Handle, Runtime},
-    task::block_in_place,
-};
+use tokio::runtime::Handle;
 use tycho_common::{
     models::{protocol::GetAmountOutParams, Chain},
     Bytes,
@@ -12,7 +9,7 @@ use tycho_common::{
 
 use crate::encoding::{
     errors::EncodingError,
-    evm::utils::get_runtime,
+    evm::utils::{create_encoding_runtime, on_blocking_thread, SafeRuntime},
     models::{EncodingContext, Swap},
     swap_encoder::SwapEncoder,
 };
@@ -22,7 +19,7 @@ pub struct HashflowSwapEncoder {
     executor_address: Bytes,
     runtime_handle: Handle,
     #[allow(dead_code)]
-    runtime: Option<Arc<Runtime>>,
+    runtime: SafeRuntime,
 }
 
 impl SwapEncoder for HashflowSwapEncoder {
@@ -31,7 +28,7 @@ impl SwapEncoder for HashflowSwapEncoder {
         _chain: Chain,
         _config: Option<HashMap<String, String>>,
     ) -> Result<Self, EncodingError> {
-        let (runtime_handle, runtime) = get_runtime()?;
+        let (runtime_handle, runtime) = create_encoding_runtime()?;
         Ok(Self { executor_address, runtime_handle, runtime })
     }
 
@@ -60,7 +57,7 @@ impl SwapEncoder for HashflowSwapEncoder {
             .ok_or(EncodingError::FatalError(
                 "The router address is needed to perform a Hashflow swap".to_string(),
             ))?;
-        let signed_quote = block_in_place(|| {
+        let signed_quote = on_blocking_thread(|| {
             self.runtime_handle.block_on(async {
                 protocol_state
                     .as_indicatively_priced()?
@@ -115,7 +112,7 @@ impl SwapEncoder for HashflowSwapEncoder {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
+    use std::{str::FromStr, sync::Arc};
 
     use alloy::hex::encode;
     use num_bigint::BigUint;

--- a/src/encoding/evm/swap_encoder/uniswap_v4.rs
+++ b/src/encoding/evm/swap_encoder/uniswap_v4.rs
@@ -161,8 +161,11 @@ impl SwapEncoder for UniswapV4SwapEncoder {
         let is_angstrom_hook = **hook_address == *self.angstrom_hook_address;
         let hook_data = if is_angstrom_hook {
             // Angstrom hook - obtain hook data from API
-            // Use block_in_place to avoid runtime dropping issues when called from async context
-            let attestations = tokio::task::block_in_place(Self::fetch_angstrom_attestations)?;
+            let attestations = std::thread::scope(|s| {
+                s.spawn(Self::fetch_angstrom_attestations)
+                    .join()
+                    .expect("attestation fetch panicked")
+            })?;
             Self::encode_angstrom_attestations(&attestations)?
         } else {
             // Regular hook - use user_data as normal

--- a/src/encoding/evm/utils.rs
+++ b/src/encoding/evm/utils.rs
@@ -138,7 +138,7 @@ pub(crate) fn create_encoding_runtime() -> Result<(Handle, SafeRuntime), Encodin
 /// Unlike `tokio::task::block_in_place`, this works on any runtime flavor
 /// (including current-thread) because the spawned thread has no tokio context.
 /// Typical usage: `on_blocking_thread(|| handle.block_on(some_future))`.
-pub(crate) fn on_blocking_thread<F, T>(f: F) -> T
+pub(crate) fn on_blocking_thread<F, T>(f: F) -> Result<T, EncodingError>
 where
     F: FnOnce() -> T + Send,
     T: Send,
@@ -146,7 +146,7 @@ where
     std::thread::scope(|s| {
         s.spawn(f)
             .join()
-            .expect("blocking thread panicked")
+            .map_err(|_| EncodingError::FatalError("blocking thread panicked".to_string()))
     })
 }
 

--- a/src/encoding/evm/utils.rs
+++ b/src/encoding/evm/utils.rs
@@ -94,19 +94,60 @@ pub(crate) fn get_static_attribute(
         .to_vec())
 }
 
-/// Returns the current Tokio runtime handle, or creates a new one if it doesn't exist.
-/// It also returns the runtime to prevent it from being dropped before use.
-/// This is required since tycho-execution does not have a pre-existing runtime.
-pub(crate) fn get_runtime() -> Result<(Handle, Option<Arc<Runtime>>), EncodingError> {
-    match Handle::try_current() {
-        Ok(h) => Ok((h, None)),
-        Err(_) => {
-            let rt = Arc::new(Runtime::new().map_err(|_| {
-                EncodingError::FatalError("Failed to create a new tokio runtime".to_string())
-            })?);
-            Ok((rt.handle().clone(), Some(rt)))
+/// A tokio `Runtime` wrapped in `Arc` that safely drops from async contexts.
+///
+/// If dropped while a tokio runtime is active on the current thread, ensures
+/// the actual runtime shutdown happens on a background OS thread, avoiding the
+/// "cannot drop a runtime in a context where blocking is not allowed" panic.
+#[derive(Clone)]
+pub(crate) struct SafeRuntime(Arc<Runtime>);
+
+impl Drop for SafeRuntime {
+    fn drop(&mut self) {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            let rt = self.0.clone();
+            std::thread::spawn(move || drop(rt));
         }
     }
+}
+
+/// Creates a dedicated multi-thread tokio runtime for encoding operations.
+///
+/// Always creates a new runtime rather than reusing the caller's, so that I/O
+/// futures are driven by dedicated worker threads regardless of the caller's
+/// runtime flavor (including current-thread runtimes like actix-web workers).
+///
+/// Returns the runtime handle and a [`SafeRuntime`] that can be dropped safely
+/// from any context.
+pub(crate) fn create_encoding_runtime() -> Result<(Handle, SafeRuntime), EncodingError> {
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .map_err(|_| {
+                EncodingError::FatalError("Failed to create encoding runtime".to_string())
+            })?,
+    );
+    let handle = rt.handle().clone();
+    Ok((handle, SafeRuntime(rt)))
+}
+
+/// Runs a closure on a fresh OS thread, blocking the caller until it completes.
+///
+/// Unlike `tokio::task::block_in_place`, this works on any runtime flavor
+/// (including current-thread) because the spawned thread has no tokio context.
+/// Typical usage: `on_blocking_thread(|| handle.block_on(some_future))`.
+pub(crate) fn on_blocking_thread<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T + Send,
+    T: Send,
+{
+    std::thread::scope(|s| {
+        s.spawn(f)
+            .join()
+            .expect("blocking thread panicked")
+    })
 }
 
 pub(crate) type EVMProvider = Arc<


### PR DESCRIPTION
block_in_place panics on current-thread tokio runtimes, which prevents callers like actix-web (whose workers use current-thread runtimes) from using RFQ swap encoders or Permit2 without elaborate workarounds -- e.g. spawning a dedicated multi-thread runtime, escaping the async context via std::thread::scope, and implementing custom Drop logic to avoid runtime shutdown panics.

Each encoder that needs async I/O now creates its own dedicated single-worker runtime and dispatches work to a fresh OS thread via std::thread::scope, which has no tokio context and can safely call Handle::block_on regardless of the caller runtime flavor. A SafeRuntime wrapper ensures the runtime can be dropped from any context without panicking.

This makes tycho-execution runtime-agnostic: callers no longer need to care about which tokio runtime flavor they use.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>