### PR TITLE
fix: Don't allow for empty sequential swaps

### DIFF
--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -739,6 +739,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
         if (minAmountOut == 0) {
             revert TychoRouter__UndefinedMinAmountOut();
         }
+        if (swaps.length == 0) {
+            revert TychoRouter__EmptySwaps();
+        }
 
         address client = clientFeeParams.clientFeeReceiver;
         // Get router fee once and pass it down to avoid duplicate external calls


### PR DESCRIPTION
Revert with TychoRouter__EmptySwaps if that is the case