### PR TITLE
fix: Zero callback amount exploit

### DIFF
--- a/foundry/src/TransferManager.sol
+++ b/foundry/src/TransferManager.sol
@@ -12,6 +12,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Vault} from "./Vault.sol";
 
 error TransferManager__AddressZero();
+error TransferManager__ZeroTransferAmount();
 error TransferManager__NotAContract(address addr);
 error TransferManager__ExceededTransferFromAllowance(
     uint256 allowedAmount, uint256 amountAttempted
@@ -144,6 +145,11 @@ contract TransferManager is Vault {
         // UniswapV3).
         if (transferType == TransferType.None) {
             return amount;
+        }
+
+        // slither-disable-next-line incorrect-equality
+        if (amount == 0) {
+            revert TransferManager__ZeroTransferAmount();
         }
 
         // Scenario 2: Native ETH sent via executor - accounting only

--- a/foundry/test/TychoRouterSequentialSwap.t.sol
+++ b/foundry/test/TychoRouterSequentialSwap.t.sol
@@ -7,6 +7,7 @@ import {
     TychoRouter__NegativeSlippage
 } from "@src/TychoRouter.sol";
 import {Vault__UnexpectedNonZeroCount} from "@src/Vault.sol";
+import {TransferManager__ZeroTransferAmount} from "@src/TransferManager.sol";
 import "./TychoRouterTestSetup.sol";
 
 // Mock executor that returns ProtocolWillDebit. The protocol never actually debits,
@@ -38,6 +39,46 @@ contract MockProtocolWillDebitExecutor is IExecutor {
         receiver = address(bytes20(data[40:60]));
         transferType = TransferManager.TransferType.ProtocolWillDebit;
         outputToRouter = true;
+    }
+}
+
+contract NormalCallbackAmountPool is TychoRouterTestSetup {
+    // Honest NO-OP pool that takes 10k WETH and gives 10k WETH
+    function swap(address, bool, int256, uint160, bytes calldata)
+        external
+        returns (int256, int256)
+    {
+        bytes memory callbackData = abi.encodeWithSignature(
+            "slipstreamsCallback(int256,int256,bytes)",
+            int256(10_000 ether), // callback amount
+            int256(0),
+            abi.encodePacked(WETH_ADDR, bytes23(0)) // token to steal
+        );
+        (bool success,) = address(msg.sender).call(callbackData);
+        IERC20(WETH_ADDR).transfer(address(msg.sender), 10_000 ether);
+        require(success, "Callback failed");
+        return (0, 0);
+    }
+}
+
+contract ZeroCallbackAmountPool is TychoRouterTestSetup {
+    // When swap() is called, calls back into TychoRouter with crafted data instructing
+    // the router to transfer zero tokens, attempting to impact delta accounting
+    // in unexpected ways. Pool transfers nothing in return.
+
+    function swap(address, bool, int256, uint160, bytes calldata)
+        external
+        returns (int256, int256)
+    {
+        bytes memory callbackData = abi.encodeWithSignature(
+            "slipstreamsCallback(int256,int256,bytes)",
+            int256(0), // callback amount
+            int256(0),
+            abi.encodePacked(WETH_ADDR, bytes23(0)) // token to steal
+        );
+        (bool success,) = address(msg.sender).call(callbackData);
+        require(success, "Callback failed");
+        return (0, 0);
     }
 }
 
@@ -588,8 +629,9 @@ contract TychoRouterSequentialSwapTest is TychoRouterTestSetup {
         tychoRouter.deposit(WETH_ADDR, amountIn);
 
         // The fake pool produces 0 output, so the USV2 swap receives 0
-        // input and reverts with INSUFFICIENT_OUTPUT_AMOUNT.
-        vm.expectRevert(bytes("UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"));
+        // input and reverts with TransferManager__ZeroTransferAmount when attempting
+        // to perform the transfer into the pool.
+        vm.expectRevert(TransferManager__ZeroTransferAmount.selector);
         tychoRouter.sequentialSwapUsingVault(
             amountIn,
             WETH_ADDR,
@@ -748,5 +790,67 @@ contract TychoRouterSequentialSwapTest is TychoRouterTestSetup {
         assertEq(IERC20(WETH_ADDR).allowance(tychoRouterAddr, fakePool), 0);
 
         vm.stopPrank();
+    }
+
+    function testZeroCallbackAmountSequentialSwap() public {
+        // Alice tries to take advantage of cyclical swap accounting using a malicious
+        // zero-amount callback pool to move router funds into her vault.
+
+        uint256 stolenAmount = 10_000 ether;
+        uint256 routerBalance = 10_000 ether;
+        deal(WETH_ADDR, tychoRouterAddr, stolenAmount);
+
+        NormalCallbackAmountPool normalPool = new NormalCallbackAmountPool();
+        ZeroCallbackAmountPool maliciousPool = new ZeroCallbackAmountPool();
+
+        deal(WETH_ADDR, ALICE, stolenAmount);
+
+        // No-op pool that trades tokens 1-1
+        deal(WETH_ADDR, address(normalPool), 10_000 ether);
+
+        // Router has some WETH that does not belong to Alice.
+        deal(WETH_ADDR, tychoRouterAddr, routerBalance);
+
+        bytes memory normalPoolProtocolData = abi.encodePacked(
+            WETH_ADDR, WETH_ADDR, bytes3(0), address(normalPool), uint8(1)
+        );
+        bytes memory zeroPoolProtocolData = abi.encodePacked(
+            WETH_ADDR, WETH_ADDR, bytes3(0), address(maliciousPool), uint8(1)
+        );
+
+        bytes[] memory swaps = new bytes[](2);
+        swaps[0] =
+            encodeSequentialSwap(address(usv3Executor), normalPoolProtocolData);
+        swaps[1] =
+            encodeSequentialSwap(address(usv3Executor), zeroPoolProtocolData);
+
+        uint256 aliceVaultBalanceBefore =
+            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
+        uint256 routerBalanceBefore =
+            IERC20(WETH_ADDR).balanceOf(tychoRouterAddr);
+
+        vm.startPrank(ALICE);
+
+        // Innermost revert is TransferManager__ZeroTransferAmount, though this isn't
+        // propagated upwards by our fake pool, so we catch "Callback failed".
+        vm.expectRevert("Callback failed");
+        tychoRouter.sequentialSwapUsingVault(
+            10_000 ether,
+            WETH_ADDR,
+            WETH_ADDR,
+            10_000 ether,
+            tychoRouterAddr,
+            noClientFee(),
+            pleEncode(swaps)
+        );
+
+        uint256 aliceVaultBalanceAfter =
+            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
+        uint256 routerBalanceAfter =
+            IERC20(WETH_ADDR).balanceOf(tychoRouterAddr);
+
+        // Alice's should not have changed.
+        assertEq(aliceVaultBalanceBefore, aliceVaultBalanceAfter);
+        assertEq(routerBalanceBefore, routerBalanceAfter);
     }
 }

--- a/foundry/test/TychoRouterSingleSwap.t.sol
+++ b/foundry/test/TychoRouterSingleSwap.t.sol
@@ -45,6 +45,27 @@ contract FalseTokenCallbackPool is TychoRouterTestSetup {
     }
 }
 
+contract ZeroCallbackAmountPool is TychoRouterTestSetup {
+    // When swap() is called, calls back into TychoRouter with crafted data instructing
+    // the router to transfer zero tokens, attempting to impact delta accounting
+    // in unexpected ways. Pool transfers nothing in return.
+
+    function swap(address, bool, int256, uint160, bytes calldata)
+        external
+        returns (int256, int256)
+    {
+        bytes memory callbackData = abi.encodeWithSignature(
+            "slipstreamsCallback(int256,int256,bytes)",
+            int256(0), // callback amount
+            int256(0),
+            abi.encodePacked(WETH_ADDR, bytes23(0)) // token to steal
+        );
+        (bool success,) = address(msg.sender).call(callbackData);
+        require(success, "Callback failed");
+        return (0, 0);
+    }
+}
+
 contract TychoRouterSingleSwapTest is TychoRouterTestSetup {
     function testSingleSwapPermit2() public {
         // Trade 1 WETH for DAI with 1 swap on Uniswap V2 using Permit2
@@ -188,6 +209,58 @@ contract TychoRouterSingleSwapTest is TychoRouterTestSetup {
         // No USDC was stolen
         assertEq(IERC20(USDC_ADDR).balanceOf(tychoRouterAddr), stolenAmount);
         assertEq(IERC20(USDC_ADDR).balanceOf(address(maliciousPool)), 0);
+    }
+
+    function testZeroCallbackAmountSingleSwap() public {
+        // Alice tries to take advantage of cyclical swap accounting using a malicious
+        // zero-amount callback pool to move router funds into her vault.
+
+        uint256 stolenAmount = 10_000 ether;
+        uint256 routerBalance = 10_000 ether;
+        deal(WETH_ADDR, tychoRouterAddr, stolenAmount);
+
+        ZeroCallbackAmountPool maliciousPool = new ZeroCallbackAmountPool();
+
+        // Malicious pool that gives no tokens and asked for 0 amount in callback
+        deal(WETH_ADDR, address(maliciousPool), stolenAmount);
+
+        // Router has some WETH that does not belong to Alice.
+        deal(WETH_ADDR, tychoRouterAddr, routerBalance);
+
+        bytes memory protocolData = abi.encodePacked(
+            WETH_ADDR, WETH_ADDR, bytes3(0), address(maliciousPool), uint8(1)
+        );
+        bytes memory swap =
+            encodeSingleSwap(address(slipstreamsExecutor), protocolData);
+
+        uint256 aliceVaultBalanceBefore =
+            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
+        uint256 routerBalanceBefore =
+            IERC20(WETH_ADDR).balanceOf(tychoRouterAddr);
+
+        vm.startPrank(ALICE);
+
+        // Innermost revert is TransferManager__ZeroTransferAmount, though this isn't
+        // propagated upwards by our fake pool, so we catch "Callback failed".
+        vm.expectRevert("Callback failed");
+        tychoRouter.singleSwapUsingVault(
+            10_000 ether,
+            WETH_ADDR,
+            WETH_ADDR,
+            1,
+            tychoRouterAddr,
+            noClientFee(),
+            swap
+        );
+
+        uint256 aliceVaultBalanceAfter =
+            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
+        uint256 routerBalanceAfter =
+            IERC20(WETH_ADDR).balanceOf(tychoRouterAddr);
+
+        // Alice's should not have changed.
+        assertEq(aliceVaultBalanceBefore, aliceVaultBalanceAfter);
+        assertEq(routerBalanceBefore, routerBalanceAfter);
     }
 
     function testSingleSwapInsufficientApproval() public {


### PR DESCRIPTION
Prevert cyclic swap delta manipulation exploits via fake pool callback data.

This was closely related to the exploit fixed in https://github.com/propeller-heads/tycho-execution/pull/83. The check that the transfer was performed is insufficient without checking that the transferred amount is nonzero.