### PR TITLE
fix: Univ3 cyclic exploit (another possible solution)

### DIFF
--- a/foundry/src/Dispatcher.sol
+++ b/foundry/src/Dispatcher.sol
@@ -18,6 +18,7 @@ error Dispatcher__NonContractExecutor();
 error Dispatcher__InvalidDataLength();
 error Dispatcher__AddressZero();
 error Dispatcher__ExecutorAlreadyExists(address executor);
+error Dispatcher__MismatchedAmount(uint256 expectedAmount, uint256 amount);
 
 /**
  * @title Dispatcher - Dispatch execution to external contracts
@@ -44,6 +45,9 @@ contract Dispatcher is TransferManager {
     // keccak256("Dispatcher#IS_FIRST_SWAP_SLOT")
     uint256 private constant _IS_FIRST_SWAP_SLOT =
         0x8c47a7e3f4c2e1b5a6d9f0e8c7b3a2d1e4f5c6b7a8d9e0f1c2b3a4d5e6f7c8d9;
+    // keccak256("Dispatcher#SWAP_INPUT_AMOUNT_SLOT")
+    uint256 private constant _SWAP_INPUT_AMOUNT_SLOT =
+        0xce9e2e8e50d57f2d688020ea7ab16e2039bcf4dc7175eba827e178586597bb39;
 
     uint256 public constant DELAY_EXECUTOR_ACTIVATION = 3 days;
 
@@ -100,6 +104,7 @@ contract Dispatcher is TransferManager {
             tstore(_IS_FIRST_SWAP_SLOT, isFirstSwap)
             tstore(_IS_SPLIT_SWAP_SLOT, isSplitSwap)
             tstore(_INPUT_TRANSFER_PERFORMED_SLOT, 0)
+            tstore(_SWAP_INPUT_AMOUNT_SLOT, amount)
         }
 
         // slither-disable-next-line calls-loop
@@ -159,6 +164,7 @@ contract Dispatcher is TransferManager {
             tstore(_CURRENTLY_SWAPPING_EXECUTOR_SLOT, 0)
             tstore(_IS_FIRST_SWAP_SLOT, 0)
             tstore(_IS_SPLIT_SWAP_SLOT, 0)
+            tstore(_SWAP_INPUT_AMOUNT_SLOT, 0)
         }
 
         // Revoke any lingering allowance the protocol didn't consume.
@@ -248,6 +254,18 @@ contract Dispatcher is TransferManager {
             (TransferManager.TransferType, address, address, uint256)
         );
 
+        uint256 expectedAmount;
+        assembly {
+            expectedAmount := tload(_SWAP_INPUT_AMOUNT_SLOT)
+        }
+        // The amount is controller by the pool during callback and can be different than the expectedAmount
+        // (set at the beginning of the swap). The TychoRouter only supports exact_in swaps, so this should never happen.
+        if (
+            amount != expectedAmount
+                && transferType != TransferManager.TransferType.None
+        ) {
+            revert Dispatcher__MismatchedAmount(expectedAmount, amount);
+        }
         _transfer(
             receiver,
             transferType,

--- a/foundry/test/protocols/UniswapV3.t.sol
+++ b/foundry/test/protocols/UniswapV3.t.sol
@@ -6,6 +6,7 @@ import "@src/executors/UniswapV3Executor.sol";
 import {Constants} from "../Constants.sol";
 import {Permit2TestHelper} from "../Permit2TestHelper.sol";
 import {Test} from "../../lib/forge-std/src/Test.sol";
+import {Dispatcher__MismatchedAmount} from "../../src/Dispatcher.sol";
 
 contract UniswapV3ExecutorExposed is UniswapV3Executor {
     constructor() UniswapV3Executor() {}
@@ -188,6 +189,46 @@ contract UniswapV3ExecutorTest is Test, TestUtils, Constants {
     }
 }
 
+// Fake UniswapV3-compatible pool used as an exploit probe.
+//
+// Triggers uniswapV3SwapCallback with amount0Delta = amountIn/2 (intentionally
+// less than the declared amountIn), causing the router to transfer that partial
+// amount here.  The pool keeps the WETH and returns nothing to the recipient.
+// This tests the partial-callback drain vector patched in Dispatcher.sol.
+contract FakeMaliciousUniV3Pool {
+    using SafeERC20 for IERC20;
+
+    address public immutable tychoRouter;
+
+    constructor(address tychoRouter_) {
+        tychoRouter = tychoRouter_;
+    }
+
+    function swap(
+        address, /* recipient */
+        bool, /* zeroForOne */
+        int256 amountSpecified,
+        uint160, /* sqrtPriceLimitX96 */
+        bytes calldata data // protocolData: tokenIn|tokenOut|fee|target|zeroForOne
+    ) external returns (int256, int256) {
+        // Claim only half of amountIn so the old cyclic adjustment
+        bytes memory callbackPayload = abi.encodeWithSelector(
+            bytes4(0xfa461e33), // callback selector
+            // This must be amount / 2 in order for the exploit to work
+            // otherwise, we get an unexpected input delta
+            int256(uint256(amountSpecified / 2)), // amount0 delta
+            int256(0), // amount1 delta
+            data // protocol data
+        );
+
+        (bool success,) = tychoRouter.call(callbackPayload);
+        require(success, "callback failed");
+
+        // Pool keeps the WETH — no transfer back to recipient.
+        return (amountSpecified, 0);
+    }
+}
+
 contract TychoRouterForUniswapV3Test is TychoRouterTestSetup {
     function testSingleSwapUSV3Permit2() public {
         // Trade 1 WETH for DAI with 1 swap on Uniswap V3 using Permit2
@@ -249,5 +290,80 @@ contract TychoRouterForUniswapV3Test is TychoRouterTestSetup {
 
         // 1000 USDC ~= 0.0095 BTC -> 1 BTC ~= 105k USDC ✅
         assertEq(IERC20(BASE_cbBTC).balanceOf(BOB), 950567);
+    }
+
+    function testCyclicVaultSwapPartialCallbackDrainReverts() public {
+        // An exploit where the pool encodes exactly half of the input amount to take
+        // during the callback. Before our fix, the numbers fit together nicely,
+        // creating an expected delta amount, allowing the malicious pool to steal
+        // router funds unnoticed.
+        //
+        // The amount in is 1 ether.
+        // The pool uses 0.5 ether, and transfers nothing out.
+        // This results in delta(WETH) = - 0.5
+        // The router balance after the swap is 0.5 ether.
+        //
+        // Before the fix, our cyclic adjustment was:
+        // balanceAfterSwap = balanceAfterSwap + amountIn
+        //                  = 0.5 + 1
+        //                  = 1.5
+        //
+        // Which means:
+        // amountOut = balanceAfterSwap - balanceBeforeSwap;
+        //           = 1.5 - 1;
+        //           = 0.5
+        //
+        // Then, when transferring the output token (0.5) back to the user,
+        // this results in an input delta of 1 ether, which is allowed, since this is
+        // exactly the amount in.
+        //
+        // After our fix we use the input delta instead of amountIn, so this is no
+        // longer possible.
+        uint256 amountIn = 1 ether;
+
+        // Seed the router with WETH (simulates tokens from other users).
+        deal(WETH_ADDR, tychoRouterAddr, amountIn);
+        uint256 routerWethBefore = IERC20(WETH_ADDR).balanceOf(tychoRouterAddr);
+
+        vm.startPrank(ALICE);
+
+        FakeMaliciousUniV3Pool fakePool =
+            new FakeMaliciousUniV3Pool(tychoRouterAddr);
+
+        // protocolData layout: tokenIn (20) | tokenOut (20) | fee (3) | target
+        // (20) | zeroForOne (1). tokenOut == tokenIn triggers cyclic detection.
+        bytes memory protocolData = abi.encodePacked(
+            WETH_ADDR, WETH_ADDR, uint24(3000), address(fakePool), false
+        );
+        bytes memory swapData =
+            encodeSingleSwap(address(usv3Executor), protocolData);
+
+        // TODO: shouldn't the error be propagated actually?
+        // Innermost revert is Dispatcher__MismatchedAmount, though this isn't
+        // propagated upwards by our fake pool, so we catch "Callback failed".
+        vm.expectRevert("callback failed");
+        tychoRouter.singleSwapUsingVault(
+            amountIn,
+            WETH_ADDR,
+            WETH_ADDR,
+            1,
+            tychoRouterAddr,
+            noClientFee(),
+            swapData
+        );
+
+        vm.stopPrank();
+
+        // EVM revert rolls back the callback transfer — no WETH was stolen.
+        assertEq(
+            IERC20(WETH_ADDR).balanceOf(tychoRouterAddr),
+            routerWethBefore,
+            "router WETH must be unchanged after the reverted drain attempt"
+        );
+        assertEq(
+            IERC20(WETH_ADDR).balanceOf(address(fakePool)),
+            0,
+            "fake pool must hold nothing after the reverted drain attempt"
+        );
     }
 }


### PR DESCRIPTION
Confirm the amount to transfer in the callback (possibly controlled by an attacker) with the amount we expected from the beginning of the swap
