### PR TITLE
fix: Incorrect client contribution behaviour with malicious pool

### DIFF
--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -24,7 +24,6 @@ import {Dispatcher} from "./Dispatcher.sol";
 import {LibSwap} from "../lib/LibSwap.sol";
 import {TransferManager} from "./TransferManager.sol";
 import {FeeRecipient} from "../lib/FeeStructs.sol";
-import {console2} from "forge-std/console2.sol";
 
 //                                         ✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷
 //                                   ✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷
@@ -76,6 +75,7 @@ error TychoRouter__NegativeSlippage(uint256 amount, uint256 minAmount);
 error TychoRouter__InvalidDataLength();
 error TychoRouter__UndefinedMinAmountOut();
 error TychoRouter__InvalidClientSignature();
+error TychoRouter__NegativeOutputDelta(int256 amount);
 error TychoRouter__ExpiredClientSignature(
     uint256 deadline, uint256 blockTimestamp
 );
@@ -1110,40 +1110,24 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
             }
             // Debit the client's vault balance
             _debitVault(client, tokenOut, requiredContribution);
-            // This would be zero in the case of a cyclical swap where
             int256 outputDelta = _getDelta(tokenOut);
-            console2.log("outputDelta:", outputDelta);
-            console2.log("required contribution:", requiredContribution);
             if (outputDelta > 0) {
-                // out tokens are still in the Router
+                // Output tokens are still in the Router. This could be because no
+                // output swap has been performed, or the user has specified the
+                // receiver to be the router in order to rebalance their vault.
                 _updateDeltaAccounting(tokenOut, int256(requiredContribution));
-            } else {
-                // send contribution separately
+            } else if (outputDelta == 0) {
                 if (receiver == address(this)) {
-                    console2.log(
-                        "Reached the right part. Crediting Bob's vault."
-                    );
-                    console2.log(
-                        "Bob's vault before crediting:",
-                        this.balanceOf(msg.sender, uint256(uint160(tokenOut)))
-                    );
-                    // ***** THE FIX *****
                     _creditVault(msg.sender, tokenOut, requiredContribution);
-                    // ***** END OF THE FIX *****
-                    console2.log(
-                        "Bob's vault after crediting:",
-                        this.balanceOf(msg.sender, uint256(uint160(tokenOut)))
-                    );
-                    int256 outputDelta = _getDelta(tokenOut);
-                    console2.log(
-                        "Output delta after client contribution:", outputDelta
-                    );
                 } else if (tokenOut == address(0)) {
                     Address.sendValue(payable(receiver), requiredContribution);
                 } else {
                     IERC20(tokenOut)
                         .safeTransfer(receiver, requiredContribution);
                 }
+            } else {
+                // Negative output delta indicates unprofitable arbitrage.
+                revert TychoRouter__NegativeOutputDelta(outputDelta);
             }
             amount = minAmountOut;
         } else {

--- a/foundry/src/TychoRouter.sol
+++ b/foundry/src/TychoRouter.sol
@@ -24,6 +24,7 @@ import {Dispatcher} from "./Dispatcher.sol";
 import {LibSwap} from "../lib/LibSwap.sol";
 import {TransferManager} from "./TransferManager.sol";
 import {FeeRecipient} from "../lib/FeeStructs.sol";
+import {console2} from "forge-std/console2.sol";
 
 //                                         ✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷
 //                                   ✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷
@@ -1109,13 +1110,35 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
             }
             // Debit the client's vault balance
             _debitVault(client, tokenOut, requiredContribution);
+            // This would be zero in the case of a cyclical swap where
             int256 outputDelta = _getDelta(tokenOut);
+            console2.log("outputDelta:", outputDelta);
+            console2.log("required contribution:", requiredContribution);
             if (outputDelta > 0) {
                 // out tokens are still in the Router
                 _updateDeltaAccounting(tokenOut, int256(requiredContribution));
             } else {
                 // send contribution separately
-                if (tokenOut == address(0)) {
+                if (receiver == address(this)) {
+                    console2.log(
+                        "Reached the right part. Crediting Bob's vault."
+                    );
+                    console2.log(
+                        "Bob's vault before crediting:",
+                        this.balanceOf(msg.sender, uint256(uint160(tokenOut)))
+                    );
+                    // ***** THE FIX *****
+                    _creditVault(msg.sender, tokenOut, requiredContribution);
+                    // ***** END OF THE FIX *****
+                    console2.log(
+                        "Bob's vault after crediting:",
+                        this.balanceOf(msg.sender, uint256(uint160(tokenOut)))
+                    );
+                    int256 outputDelta = _getDelta(tokenOut);
+                    console2.log(
+                        "Output delta after client contribution:", outputDelta
+                    );
+                } else if (tokenOut == address(0)) {
                     Address.sendValue(payable(receiver), requiredContribution);
                 } else {
                     IERC20(tokenOut)

--- a/foundry/src/Vault.sol
+++ b/foundry/src/Vault.sol
@@ -12,7 +12,6 @@ import {
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {ERC6909} from "@openzeppelin/contracts/token/ERC6909/ERC6909.sol";
 
-import {console2} from "forge-std/console2.sol";
 error Vault__InsufficientBalance(
     address user, address token, uint256 requested, uint256 available
 );
@@ -339,7 +338,6 @@ abstract contract Vault is ERC6909, ReentrancyGuard, Pausable {
         bool useVault = _getUseVault();
 
         if (useVault) {
-            console2.log("nonZeroCount in _finalizeBalances:", nonZeroCount);
             // When vault usage is allowed, allow a single negative delta
             // Check that there is only one negative delta: the input token
             if (nonZeroCount > 1) {
@@ -350,7 +348,6 @@ abstract contract Vault is ERC6909, ReentrancyGuard, Pausable {
                     revert Vault__UnexpectedInputDelta(inputDelta);
                 }
                 uint256 id = _toId(inputToken);
-                console2.log("Burning Bob's debts:", inputDelta);
                 _burn(user, id, inputAmount);
             }
         } else {

--- a/foundry/src/Vault.sol
+++ b/foundry/src/Vault.sol
@@ -12,6 +12,7 @@ import {
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {ERC6909} from "@openzeppelin/contracts/token/ERC6909/ERC6909.sol";
 
+import {console2} from "forge-std/console2.sol";
 error Vault__InsufficientBalance(
     address user, address token, uint256 requested, uint256 available
 );
@@ -338,6 +339,7 @@ abstract contract Vault is ERC6909, ReentrancyGuard, Pausable {
         bool useVault = _getUseVault();
 
         if (useVault) {
+            console2.log("nonZeroCount in _finalizeBalances:", nonZeroCount);
             // When vault usage is allowed, allow a single negative delta
             // Check that there is only one negative delta: the input token
             if (nonZeroCount > 1) {
@@ -348,6 +350,7 @@ abstract contract Vault is ERC6909, ReentrancyGuard, Pausable {
                     revert Vault__UnexpectedInputDelta(inputDelta);
                 }
                 uint256 id = _toId(inputToken);
+                console2.log("Burning Bob's debts:", inputDelta);
                 _burn(user, id, inputAmount);
             }
         } else {

--- a/foundry/test/TestUtils.sol
+++ b/foundry/test/TestUtils.sol
@@ -1,6 +1,10 @@
 pragma solidity ^0.8.10;
 
 import "forge-std/Test.sol";
+import {
+    SafeERC20,
+    IERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract TestUtils is Test {
     constructor() {}
@@ -43,3 +47,15 @@ contract FakeSlipstreamPool {
     }
 }
 
+// Fake Curve pool that accepts any swap call tries to steal because we gave it allowances
+contract FakeCurvePool {
+    using SafeERC20 for IERC20;
+
+    function exchange(uint256 i, uint256 j, uint256 dx, uint256 minDy)
+        external
+    {
+        // ignoring the indices for simplicity
+        address token = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+        IERC20(token).transferFrom(msg.sender, address(this), dx);
+    }
+}

--- a/foundry/test/TestUtils.sol
+++ b/foundry/test/TestUtils.sol
@@ -47,7 +47,7 @@ contract FakeSlipstreamPool {
     }
 }
 
-// Fake Curve pool that accepts any swap call tries to steal because we gave it allowances
+// Fake Curve pool that accepts any swap, performs a transferFrom, and does nothing
 contract FakeCurvePool {
     using SafeERC20 for IERC20;
 
@@ -57,5 +57,20 @@ contract FakeCurvePool {
         // ignoring the indices for simplicity
         address token = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
         IERC20(token).transferFrom(msg.sender, address(this), dx);
+    }
+}
+
+// Fake Curve pool that accepts any swap, performs a transferFrom, and transfers it
+// back to the router
+contract OneToOneCurvePool {
+    using SafeERC20 for IERC20;
+
+    function exchange(uint256 i, uint256 j, uint256 dx, uint256 minDy)
+        external
+    {
+        // ignoring the indices for simplicity
+        address token = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+        IERC20(token).transferFrom(msg.sender, address(this), dx);
+        IERC20(token).transfer(msg.sender, dx);
     }
 }

--- a/foundry/test/TychoRouterVault.t.sol
+++ b/foundry/test/TychoRouterVault.t.sol
@@ -398,7 +398,7 @@ contract TychoRouterUsingVaultTest is TychoRouterTestSetup {
         uint256 aliceVaultBalanceAfter =
             tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
         uint256 bobVaultBalanceAfter =
-            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
+            tychoRouter.balanceOf(BOB, uint256(uint160(WETH_ADDR)));
         console.logString("Alice balance before:");
         console.logUint(aliceVaultBalanceBefore);
         console.logString("Alice balance after:");

--- a/foundry/test/TychoRouterVault.t.sol
+++ b/foundry/test/TychoRouterVault.t.sol
@@ -1,7 +1,11 @@
 pragma solidity ^0.8.26;
 
 import "@src/executors/UniswapV4Executor.sol";
-import {TychoRouter, ClientFeeParams} from "@src/TychoRouter.sol";
+import {
+    TychoRouter,
+    ClientFeeParams,
+    TychoRouter__NegativeOutputDelta
+} from "@src/TychoRouter.sol";
 import {
     Vault__UnexpectedInputDelta,
     Vault__UnexpectedNonZeroCount,
@@ -346,7 +350,14 @@ contract TychoRouterUsingVaultTest is TychoRouterTestSetup {
         vm.stopPrank();
     }
 
-    function testAllowanceIssue() public {
+    function testNegativeOutputCyclicalSwap() public {
+        // Performs a cyclical swap on a pool which transfers the input amount while
+        // offering no output in return. The client contribution is 1 ether, so the
+        // client makes up for the whole amount. However, since this pool result in
+        // a negative delta at the time of computing client fees, an unprofitable
+        // arbitrage is detected and the TychoRouter reverts with
+        // TychoRouter__NegativeOutputDelta
+
         uint256 stolenAmount = 1 ether;
         // The client (Alice) will contribute to this swap with their own funds
         uint256 clientContribution = stolenAmount;
@@ -377,14 +388,12 @@ contract TychoRouterUsingVaultTest is TychoRouterTestSetup {
         ClientFeeParams memory feeParams =
             makeClientFeeParams(0, stolenAmount, tychoRouterAddr, ALICE_PK);
 
-        uint256 tychoBalanceBefore =
-            IERC20(WETH_ADDR).balanceOf(tychoRouterAddr);
-
-        uint256 aliceVaultBalanceBefore =
-            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
-        uint256 bobVaultBalanceBefore =
-            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
-
+        int256 negativeOutput = -int256(stolenAmount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TychoRouter__NegativeOutputDelta.selector, negativeOutput
+            )
+        );
         tychoRouter.singleSwapUsingVault(
             stolenAmount,
             WETH_ADDR,
@@ -394,82 +403,62 @@ contract TychoRouterUsingVaultTest is TychoRouterTestSetup {
             feeParams,
             swap
         );
+    }
 
-        uint256 aliceVaultBalanceAfter =
+    function testZeroOutputDeltaClientContribution() public {
+        // The pool returns the same amount as it gets, so the output delta is zero.
+        // However, Bob has requested twice this amount, so the rest comes from
+        // Alice's client contribution.
+
+        uint256 inputAmount = 1 ether;
+
+        // The client (Alice) will contribute to this swap with their own funds
+        uint256 clientContribution = inputAmount;
+        vm.startPrank(ALICE);
+        deal(WETH_ADDR, ALICE, clientContribution);
+        IERC20(WETH_ADDR).approve(address(tychoRouterAddr), inputAmount);
+        tychoRouter.deposit(WETH_ADDR, clientContribution);
+
+        vm.stopPrank();
+        vm.startPrank(BOB);
+        deal(WETH_ADDR, BOB, inputAmount);
+        IERC20(WETH_ADDR).approve(address(tychoRouterAddr), inputAmount);
+        tychoRouter.deposit(WETH_ADDR, inputAmount);
+
+        OneToOneCurvePool oneToOnePool = new OneToOneCurvePool();
+
+        bytes memory protocolData = abi.encodePacked(
+            WETH_ADDR,
+            WETH_ADDR,
+            address(oneToOnePool),
+            uint8(3),
+            uint8(1),
+            uint8(1)
+        );
+        bytes memory swap =
+            encodeSingleSwap(address(curveExecutor), protocolData);
+
+        ClientFeeParams memory feeParams =
+            makeClientFeeParams(0, inputAmount, tychoRouterAddr, ALICE_PK);
+
+        int256 negativeOutput = -int256(inputAmount);
+        tychoRouter.singleSwapUsingVault(
+            inputAmount,
+            WETH_ADDR,
+            WETH_ADDR,
+            2 * inputAmount,
+            tychoRouterAddr,
+            feeParams,
+            swap
+        );
+        uint256 aliceBalance =
             tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
-        uint256 bobVaultBalanceAfter =
+        uint256 bobBalance =
             tychoRouter.balanceOf(BOB, uint256(uint160(WETH_ADDR)));
-        console.logString("Alice balance before:");
-        console.logUint(aliceVaultBalanceBefore);
-        console.logString("Alice balance after:");
-        console.logUint(aliceVaultBalanceAfter);
-
-        console.logString("Bob balance before:");
-        console.logUint(bobVaultBalanceBefore);
-        console.logString("Bob balance after:");
-        console.logUint(bobVaultBalanceAfter);
-
-        uint256 tychoBalanceAfter = IERC20(WETH_ADDR).balanceOf(tychoRouterAddr);
-        console.logString("Tycho balance before:");
-        console.logUint(tychoBalanceBefore);
-        console.logString("Tycho balance after:");
-        console.logUint(tychoBalanceAfter);
-        //  **** BEFORE FIX ****
-        //  Alice balance before:
-        //  1000000000000000000
-        //  Alice balance after:
-        //  0
-
-        //  Bob balance before:
-        //  1000000000000000000
-        //  Bob balance after:
-        //  0
-        //  Bob should have gotten Alice's contribution - but Alice's contribution went
-        //  to the pool, so both Bob and Alice are left with nothing.
-        //  Technically, only 1000000000000000000 was stolen from the TychoRouter, but
-        //  neither Bob not Alice can access this amount anymore since their Vault
-        //  accounting says they have nothing.
-        //  Who wins in the end? The malicious pool, if controlled by Bob, now has
-        //  Bob's funds, so he wins nothing. BUT he has managed to mess up Alice's
-        //  vault balance.
-
-        //  Tycho balance before:
-        //  2000000000000000000
-        //  Tycho balance after:
-        //  1000000000000000000
-
-        //  maliciousPool balance after:
-        //  1000000000000000000
-
-        //
-        //  **** AFTER FIX ****
-        //  Alice balance before:
-        //  1000000000000000000
-        //  Alice balance after:
-        //  0
-
-        //  Bob balance before:
-        //  1000000000000000000
-        //  Bob balance after:
-        //  1000000000000000000
-        //
-        //  Alice's vault funds rightfully went to Bob after the pool stole the
-        //  allowance. Alice should not have set her client contribution so high.
-        //  An even better fix would be to totally revert here.
-
-        //  Tycho balance before:
-        //  2000000000000000000
-        //  Tycho balance after:
-        //  1000000000000000000
-
-        //  maliciousPool balance after:
-        //  1000000000000000000
-
-        uint256 maliciousPoolBalanceAfter =
-            IERC20(WETH_ADDR).balanceOf(address(maliciousPool));
-
-        console.logString("maliciousPool balance after:");
-        console.logUint(maliciousPoolBalanceAfter);
+        assertEq(aliceBalance, 0);
+        // Bob should now have his original amount plus Alice's contribution
+        assertEq(bobBalance, 2 * inputAmount);
+        assertEq(IERC20(WETH_ADDR).balanceOf(tychoRouterAddr), 2 * inputAmount);
     }
 
     // ==================== Rebalance Vault tests ====================

--- a/foundry/test/TychoRouterVault.t.sol
+++ b/foundry/test/TychoRouterVault.t.sol
@@ -348,7 +348,7 @@ contract TychoRouterUsingVaultTest is TychoRouterTestSetup {
 
     function testAllowanceIssue() public {
         uint256 stolenAmount = 1 ether;
-        // The client will contribute to this swap with their own funds
+        // The client (Alice) will contribute to this swap with their own funds
         uint256 clientContribution = stolenAmount;
         vm.startPrank(ALICE);
         deal(WETH_ADDR, ALICE, clientContribution);
@@ -376,23 +376,75 @@ contract TychoRouterUsingVaultTest is TychoRouterTestSetup {
 
         ClientFeeParams memory feeParams =
             makeClientFeeParams(0, stolenAmount, tychoRouterAddr, ALICE_PK);
+
+        uint256 tychoBalanceBefore =
+            IERC20(WETH_ADDR).balanceOf(tychoRouterAddr);
+
+        uint256 aliceVaultBalanceBefore =
+            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
+        uint256 bobVaultBalanceBefore =
+            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
+
         tychoRouter.singleSwapUsingVault(
             stolenAmount,
             WETH_ADDR,
             WETH_ADDR,
             stolenAmount,
-            BOB,
+            tychoRouterAddr,
             feeParams,
             swap
         );
 
-        // ALICE (client) doesn't have funds anymore
-        assertEq(tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR))), 0);
-        // Attacker BOB and maliciousPool have both stolenAmount
-        assertEq(IERC20(WETH_ADDR).balanceOf(BOB), stolenAmount); // from BOB's own vault
-        assertEq(
-            IERC20(WETH_ADDR).balanceOf(address(maliciousPool)), stolenAmount
-        ); // from the client contribution
+        uint256 aliceVaultBalanceAfter =
+            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
+        uint256 bobVaultBalanceAfter =
+            tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR)));
+        console.logString("Alice balance before:");
+        console.logUint(aliceVaultBalanceBefore);
+        console.logString("Alice balance after:");
+        console.logUint(aliceVaultBalanceAfter);
+
+        console.logString("Bob balance before:");
+        console.logUint(bobVaultBalanceBefore);
+        console.logString("Bob balance after:");
+        console.logUint(bobVaultBalanceAfter);
+
+        uint256 tychoBalanceAfter = IERC20(WETH_ADDR).balanceOf(tychoRouterAddr);
+        console.logString("Tycho balance before:");
+        console.logUint(tychoBalanceBefore);
+        console.logString("Tycho balance after:");
+        console.logUint(tychoBalanceAfter);
+        //  Alice balance before:
+        //  1000000000000000000
+        //  Alice balance after:
+        //  0
+
+        //  Bob balance before:
+        //  1000000000000000000
+        //  Bob balance after:
+        //  0
+        //  Bob should have gotten Alice's contribution - but Alice's contribution went
+        //  to the pool, so both Bob and Alice are left with nothing.
+        //  Technically, only 1000000000000000000 was stolen from the TychoRouter, but
+        //  neither Bob not Alice can access this amount anymore since their Vault
+        //  accounting says they have nothing.
+        //  Who wins in the end? The malicious pool, if controlled by Bob, now has
+        //  Bob's funds, so he wins nothing. BUT he has managed to mess up Alice's
+        //  vault balance.
+
+        //  Tycho balance before:
+        //  2000000000000000000
+        //  Tycho balance after:
+        //  1000000000000000000
+
+        //  maliciousPool balance after:
+        //  1000000000000000000
+
+        uint256 maliciousPoolBalanceAfter =
+            IERC20(WETH_ADDR).balanceOf(address(maliciousPool));
+
+        console.logString("maliciousPool balance after:");
+        console.logUint(maliciousPoolBalanceAfter);
     }
 
     // ==================== Rebalance Vault tests ====================

--- a/foundry/test/TychoRouterVault.t.sol
+++ b/foundry/test/TychoRouterVault.t.sol
@@ -346,6 +346,55 @@ contract TychoRouterUsingVaultTest is TychoRouterTestSetup {
         vm.stopPrank();
     }
 
+    function testAllowanceIssue() public {
+        uint256 stolenAmount = 1 ether;
+        // The client will contribute to this swap with their own funds
+        uint256 clientContribution = stolenAmount;
+        vm.startPrank(ALICE);
+        deal(WETH_ADDR, ALICE, clientContribution);
+        IERC20(WETH_ADDR).approve(address(tychoRouterAddr), stolenAmount);
+        tychoRouter.deposit(WETH_ADDR, clientContribution);
+
+        vm.stopPrank();
+        vm.startPrank(BOB);
+        deal(WETH_ADDR, BOB, stolenAmount);
+        IERC20(WETH_ADDR).approve(address(tychoRouterAddr), stolenAmount);
+        tychoRouter.deposit(WETH_ADDR, stolenAmount);
+
+        FakeCurvePool maliciousPool = new FakeCurvePool();
+
+        bytes memory protocolData = abi.encodePacked(
+            WETH_ADDR,
+            WETH_ADDR,
+            address(maliciousPool),
+            uint8(3),
+            uint8(1),
+            uint8(1)
+        );
+        bytes memory swap =
+            encodeSingleSwap(address(curveExecutor), protocolData);
+
+        ClientFeeParams memory feeParams =
+            makeClientFeeParams(0, stolenAmount, tychoRouterAddr, ALICE_PK);
+        tychoRouter.singleSwapUsingVault(
+            stolenAmount,
+            WETH_ADDR,
+            WETH_ADDR,
+            stolenAmount,
+            BOB,
+            feeParams,
+            swap
+        );
+
+        // ALICE (client) doesn't have funds anymore
+        assertEq(tychoRouter.balanceOf(ALICE, uint256(uint160(WETH_ADDR))), 0);
+        // Attacker BOB and maliciousPool have both stolenAmount
+        assertEq(IERC20(WETH_ADDR).balanceOf(BOB), stolenAmount); // from BOB's own vault
+        assertEq(
+            IERC20(WETH_ADDR).balanceOf(address(maliciousPool)), stolenAmount
+        ); // from the client contribution
+    }
+
     // ==================== Rebalance Vault tests ====================
     function testSingleSwapIntoVault() public {
         // Trade 1 WETH for DAI with 1 swap on Uniswap V2, with the receiver

--- a/foundry/test/TychoRouterVault.t.sol
+++ b/foundry/test/TychoRouterVault.t.sol
@@ -414,6 +414,7 @@ contract TychoRouterUsingVaultTest is TychoRouterTestSetup {
         console.logUint(tychoBalanceBefore);
         console.logString("Tycho balance after:");
         console.logUint(tychoBalanceAfter);
+        //  **** BEFORE FIX ****
         //  Alice balance before:
         //  1000000000000000000
         //  Alice balance after:
@@ -431,6 +432,30 @@ contract TychoRouterUsingVaultTest is TychoRouterTestSetup {
         //  Who wins in the end? The malicious pool, if controlled by Bob, now has
         //  Bob's funds, so he wins nothing. BUT he has managed to mess up Alice's
         //  vault balance.
+
+        //  Tycho balance before:
+        //  2000000000000000000
+        //  Tycho balance after:
+        //  1000000000000000000
+
+        //  maliciousPool balance after:
+        //  1000000000000000000
+
+        //
+        //  **** AFTER FIX ****
+        //  Alice balance before:
+        //  1000000000000000000
+        //  Alice balance after:
+        //  0
+
+        //  Bob balance before:
+        //  1000000000000000000
+        //  Bob balance after:
+        //  1000000000000000000
+        //
+        //  Alice's vault funds rightfully went to Bob after the pool stole the
+        //  allowance. Alice should not have set her client contribution so high.
+        //  An even better fix would be to totally revert here.
 
         //  Tycho balance before:
         //  2000000000000000000


### PR DESCRIPTION
# What was happening?
1. Alice agrees to pay 1000 WETH as a client contribution (unwise decision).
2. Bob wants to trade 1000 WETH for 1000 WETH. 
3. Bob accidentally encodes a malicious pool that takes 1000 WETH and returns nothing.
4. Bob encodes the receiver to be the TychoRouter, so that resulting funds should go to his vault balance.

**Math:**
```
amount = 1000 WETH
tychoRouterBalanceBeforeSwap = 2000 WETH (1000 belongs to Bob, 1000 belongs Alice)

tychoRouterBalanceAfterSwap = 1000 WETH (1000 taken from Bob's Vault). Bob's Vault is now empty - it has been transferred to the pool.

amountOut = balanceAfterSwap + amount - balanceBeforeSwap
          = 1000 WETH + 1000 WETH - 2000 WETH
          = 0 WETH

amountOut is correctly reported as 0.

Alice's client contribution is 1000 WETH.
Alice sends 1000 WETH to TychoRouter. THIS WAS NOT ACCOUNTED FOR in Bob's vault balance.
```

Since the output delta is now less than zero (stolen by malicious pool), in `_maybeAddClientContribution` we were assuming the tokens have already been sent to the receiver. Normally in that case, we also send the client contribution directly to the receiver:

```
if (outputDelta > 0) {
    // out tokens are still in the Router
    _updateDeltaAccounting(tokenOut, int256(requiredContribution));
} else {                        <--------- it landed HERE, sending tokens to the tychoRouter
    if (tokenOut == address(0)) {
        Address.sendValue(payable(receiver), requiredContribution);
    } else {
        IERC20(tokenOut).safeTransfer(receiver, requiredContribution);
    }
}
```

The receiver in this case is the TychoRouter, so we are sending tokens from Alice’s vault into the TychoRouter, without actually ever crediting Bob - so both Alice (the client) and Bob (msg.sender) lose vault Balance while gaining nothing.

Supporting logs before any fixes:
```
        //  **** BEFORE FIX ****
        //  Alice balance before:
        //  1000000000000000000
        //  Alice balance after:
        //  0

        //  Bob balance before:
        //  1000000000000000000
        //  Bob balance after:
        //  0
   
        //  Bob should have gotten Alice's contribution - but Alice's contribution went
        //  to the pool, so both Bob and Alice are left with nothing.
        //  Technically, only 1000000000000000000 was stolen from the TychoRouter, but
        //  neither Bob nor Alice can access this amount anymore since their Vault
        //  accounting says they have nothing.
        //  Who wins in the end? The malicious pool, if controlled by Bob, now has
        //  Bob's funds, so he wins nothing. BUT he has managed to mess up Alice's
        //  vault balance. If the malicious pool was somehow badly injected in the calldata
        //  and not controlled by Bob, Alice has lost her contribution to the pool address. This could
        //  have been prevented by setting a lower contribution. Such a high contribution is always
        //  susceptible to MEV attacks anyway.

        //  Tycho balance before:
        //  2000000000000000000
        //  Tycho balance after:
        //  1000000000000000000

        //  maliciousPool balance after:
        //  1000000000000000000
```

# How to fix this?
**Two ways:**
- Check if delta <= 0, revert
- if delta == 0 and receiver == address(this), credit msg.sender instead of transferring. 
